### PR TITLE
Topic/add src tests proposal v1

### DIFF
--- a/test/README
+++ b/test/README
@@ -1,0 +1,64 @@
+SOF Audio Processing Components Tests
+=====================================
+
+This is a set of test scripts to test that performance requirements
+are met. The tests are currently for measured audio objective quality
+parameters. The used criteria for performance is only an initial
+assumption and need to be adjusted for various applications needs.
+
+The scripts support currently support the next list of objective
+quality parameters. The test scripts need Matlab(R) [2] or GNU Octave
+scientific programming language [3].
+
+	- Gain
+	- Frequency Response
+	- THD+N vs. Frequency
+	- Dynamic Range
+	- Attenuation of Alias Products
+	- Attenuation of Image Products
+
+Note: The metric is an effort to follow AES17 [1] recommendation for
+parameters and test procedures. This was created to help developers to
+quickly check their work but has not been verified to be
+compliant. Professional equipment and formal calibration process is
+recommended for professional applications where both accurate absolute
+and relative metric is needed.
+
+Note: The test bench uses by default raw binary data files. It is
+possible to convert with SoX (v14.4.1) [4] the raw data to e.g. wav
+format for other audio tools and subjective listening.
+
+$ sox -b 32 -c 2 -r 48000 -L -e signed-integer fr_test_out.raw fr_test_out.wav
+
+For debugging purposes it is possible to switch from test scripts the
+test vectors format to txt for easy manual data creation and
+inspection.
+
+
+Tests for component SRC
+-----------------------
+
+The top level shell script to launch tests is src_test.sh. See script
+src_run.sh for assumed install location of SOF host test bench
+executable and component libraries. Exit code 0 indicates success and
+exit code 1 indicates failed test cases.
+
+The default in/out rates matrix to test is defined in the beginning of
+script src_test.m. The matrix can be also passed from calling function
+src_test_top.m if need.
+
+The key objective quality parameters requiremements are in the
+beginning of script src_test.m as well under comment Generic test
+pass/fail criteria.
+
+Test run creates plots into directory "plots". Brief text format
+reports are placed to directory "reports".
+
+
+References
+----------
+
+[1]	AES17-1015 standard, http://www.aes.org/publications/standards/search.cfm?docID=21
+[2]	Matlab(R), https://www.mathworks.com/products/matlab.html
+[3]	GNU Octave, https://www.gnu.org/software/octave/
+[4]	SoX - Sound eXchange, http://sox.sourceforge.net/

--- a/test/src_run.sh
+++ b/test/src_run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# SRC specifics
+COMP=src
+BITS_IN=$1
+BITS_OUT=$2
+FS1=$3
+FS2=$4
+FN_IN=$5
+FN_OUT=$6
+
+# The HOST_ROOT path need to be retrived from SOFT .configure command
+HOST_ROOT=../../host-root
+HOST_EXE=$HOST_ROOT/bin/testbench
+HOST_LIB=$HOST_ROOT/lib
+
+# Topology
+INFMT=s${BITS_IN}le
+OUTFMT=s${BITS_IN}le
+MCLK=24576k
+TPLG=../topology/test/test-playback-ssp2-I2S-${COMP}-${INFMT}-${OUTFMT}-48k-${MCLK}-nocodec.tplg
+
+# If binary test vectors
+if [ ${FN_IN: -4} == ".raw" ]; then
+    CMDFMT="-b S${BITS_IN}_LE"
+else
+    CMDFMT=""
+fi
+
+# Run command
+CMD0=$HOST_EXE
+CMD1="-d -x $FS1 -y $FS2 -i $FN_IN -o $FN_OUT -t $TPLG -a src=libsof_${COMP}.so $CMDFMT"
+CMD="$CMD0 $CMD1"
+export LD_LIBRARY_PATH=$HOST_LIB
+
+# Run test bench
+echo "Command: $CMD0"
+echo "Arg:     $CMD1"
+$CMD

--- a/test/src_test.m
+++ b/test/src_test.m
@@ -1,0 +1,607 @@
+function [n_fail, n_pass, n_na] = src_test(bits_in, bits_out, fs_in_list, fs_out_list)
+
+%%
+% src_test - test with SRC test bench objective audio quality parameters
+%
+% src_test(fs_in, fs_out)
+%
+% bits_in  - input word length
+% bits_out - output word length
+% fs_in    - vector of rates in
+% fs_out   - vector of rates out
+%
+% A default in-out matrix with 32 bits data is tested if the
+% paremeters are omitted.
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+addpath('std_utils');
+addpath('test_utils');
+addpath('../tune/src');
+mkdir_check('plots');
+mkdir_check('reports');
+
+%% Defaults for call parameters
+if nargin < 1
+	bits_in = 32;
+end
+if nargin < 2
+	bits_out = 32;
+end
+if nargin < 3
+        fs_in_list = [8e3 11025 12e3 16e3 18900 22050 24e3 32e3 44100 48e3 ...
+			  64e3 88.2e3 96e3 176400 192e3];
+end
+if nargin < 4
+	fs_out_list = [8e3 11025 12e3 16e3 18900 22050 24e3 32e3 44100 48e3];
+end
+
+%% Generic test pass/fail criteria
+%  Note that AAP and AIP are relaxed a bit from THD+N due to inclusion
+%  of point Fs/2 to test. The stopband of kaiser FIR is not equiripple
+%  and there's sufficient amount of attnuation at higher frequencies to
+%  meet THD+N requirement.
+t.g_db_tol = 0.1;
+t.thdnf_db_max = -80;
+t.dr_db_min = 100;
+t.aap_db_max = -60;
+t.aip_db_max = -60;
+
+%% Defaults for test
+t.fmt = 'raw';         % Can be 'raw' (fast binary) or 'txt' (debug)
+t.nch = 2;             % Number of channels
+t.ch = 0;              % 1..nch. With value 0 test a randomly selected channel.
+t.bits_in = bits_in;   % Input word length
+t.bits_out = bits_out; % Output word length
+t.full_test = 1;       % 0 is quick check only, 1 is full set
+
+%% Show graphics or not. With visible plot windows Octave may freeze if too
+%  many windows are kept open. As workaround setting close windows to
+%  1 shows only flashing windows while the test proceeds. With
+%  visibility set to to 0 only console text is seen. The plots are
+%  exported into plots directory in png format and can be viewed from
+%  there.
+t.close_plot_windows = 0;  % Workaround for visible windows if Octave hangs
+t.visible = 'off';         % Use off for batch tests and on for interactive
+t.delete = 1;              % Set to 0 to inspect the audio data files
+
+%% Init for test loop
+n_test = 7; % We have next seven test cases for SRC
+n_fsi = length(fs_in_list);
+n_fso = length(fs_out_list);
+r.fs_in_list = fs_in_list;
+r.fs_out_list = fs_out_list;
+r.g = NaN(n_fsi, n_fso);
+r.dr = NaN(n_fsi, n_fso);
+r.fr_db = NaN(n_fsi, n_fso);
+r.fr_hz = NaN(n_fsi, n_fso, 2);
+r.fr3db_hz = NaN(n_fsi, n_fso);
+r.thdnf = NaN(n_fsi, n_fso);
+r.aap = NaN(n_fsi, n_fso);
+r.aip = NaN(n_fsi, n_fso);
+r.pf = NaN(n_fsi, n_fso, n_test);
+r.n_fail = 0;
+r.n_pass = 0;
+r.n_skipped = 0;
+r.n_na = 0;
+%% Loop all modes to test
+for b = 1:n_fso
+        for a = 1:n_fsi
+                v = -ones(n_test,1); % Set pass/fail test verdict to not executed
+                tn = 1;
+                t.fs1 = fs_in_list(a);
+                t.fs2 = fs_out_list(b);
+                v(1) = chirp_test(t);
+                if v(1) ~= -1 && t.full_test == 1
+                        %% Chirp was processed so this in/out Fs is supported
+                        [v(2), r.g(a,b)] = g_test(t);
+                        [v(3), r.fr_db(a,b), r.fr_hz(a,b,:), r.fr3db_hz(a,b)] = fr_test(t);
+                        [v(4), r.thdnf(a,b)] = thdnf_test(t);
+                        [v(5), r.dr(a,b)] = dr_test(t);
+                        [v(6), r.aap(a,b)] = aap_test(t);
+                        [v(7), r.aip(a,b)] = aip_test(t);
+                end
+                %% Done, store pass/fail
+                r.pf(a, b, :) = v;
+		if v(1) ~= -1
+			idx = find(v > 0);
+			r.n_fail = r.n_fail + length(idx);
+			idx = find(v == 0);
+			r.n_pass = r.n_pass + length(idx);
+			idx = find(v == -1);
+			r.n_skipped = r.n_skipped + length(idx);
+			idx = find(v == -2);
+			r.n_na = r.n_na + length(idx);
+		end
+        end
+end
+
+%% Print table with test summary: Gain
+fn = 'reports/g_src.txt';
+print_val(fn, fs_in_list, fs_out_list, r.g, r.pf, 'Gain dB');
+
+%% Print table with test summary: FR
+fn = 'reports/fr_src.txt';
+print_fr(fn, fs_in_list, fs_out_list, r.fr_db, r.fr_hz, r.pf);
+
+%% Print table with test summary: FR
+fn = 'reports/fr_src.txt';
+print_val(fn, fs_in_list, fs_out_list, r.fr3db_hz/1e3, r.pf, ...
+        'Frequency response -3 dB 0 - X kHz');
+
+%% Print table with test summary: THD+N vs. frequency
+fn = 'reports/thdnf_src.txt';
+print_val(fn, fs_in_list, fs_out_list, r.thdnf, r.pf, ...
+        'Worst-case THD+N vs. frequency');
+
+%% Print table with test summary: DR
+fn = 'reports/dr_src.txt';
+print_val(fn, fs_in_list, fs_out_list, r.dr, r.pf, ...
+        'Dynamic range dB (CCIR-RMS)');
+
+%% Print table with test summary: AAP
+fn = 'reports/aap_src.txt';
+print_val(fn, fs_in_list, fs_out_list, r.aap, r.pf, ...
+        'Attenuation of alias products dB');
+
+%% Print table with test summary: AIP
+fn = 'reports/aip_src.txt';
+print_val(fn, fs_in_list, fs_out_list, r.aip, r.pf, ...
+        'Attenuation of image products dB');
+
+
+%% Print table with test summary: pass/fail
+fn = 'reports/pf_src.txt';
+print_pf(fn, fs_in_list, fs_out_list, r.pf);
+
+fprintf('\n');
+fprintf('Number of passed tests = %d\n', r.n_pass);
+fprintf('Number of failed tests = %d\n', r.n_fail);
+fprintf('Number of non-applicable tests = %d\n', r.n_na);
+fprintf('Number of skipped tests = %d\n', r.n_skipped);
+
+
+if r.n_fail > 0 || r.n_pass < 1
+	fprintf('\nERROR: TEST FAILED!!!\n');
+else
+	fprintf('\nTest passed.\n');
+end
+
+n_fail = r.n_fail;
+n_pass = r.n_pass;
+n_na = r.n_na;
+
+end
+
+
+%%
+%% Test execution with help of common functions
+%%
+
+function [fail, g_db] = g_test(t)
+
+%% Reference: AES17 6.2.2 Gain
+test = test_defaults_src(t);
+prm = src_param(t.fs1, t.fs2, test.coef_bits);
+test.fu = prm.c_pb*min(t.fs1,t.fs2);
+test.g_db_tol = t.g_db_tol;
+test.g_db_expect = 0;
+
+%% Create input file
+test = g_test_input(test);
+
+%% Run test
+test = test_run_src(test, t);
+
+%% Measure
+test.fs = t.fs2;
+test = g_test_measure(test);
+
+%% Get output parameters
+fail = test.fail;
+g_db = test.g_db;
+delete_check(t.delete, test.fn_in);
+delete_check(t.delete, test.fn_out);
+
+end
+
+function [fail, pm_range_db, range_hz, fr3db_hz] = fr_test(t)
+
+%% Reference: AES17 6.2.3 Frequency response
+test = test_defaults_src(t);
+prm = src_param(t.fs1, t.fs2, test.coef_bits);
+
+test.rp_max = prm.rp_tot;      % Max. ripple +/- dB allowed
+test.f_lo = 20;                % For response reporting, measure from 20 Hz
+test.f_hi = min(t.fs1,t.fs2)*prm.c_pb;   % to designed filter upper frequency
+test.f_max = min(t.fs1/2, t.fs2/2); % Measure up to Nyquist frequency
+
+%% Create input file
+test = fr_test_input(test);
+
+%% Run test
+test = test_run_src(test, t);
+
+%% Measure
+test.fs = t.fs2;
+test = fr_test_measure(test);
+
+fail = test.fail;
+pm_range_db = test.rp;
+range_hz = [test.f_lo test.f_hi];
+fr3db_hz = test.fr3db_hz;
+delete_check(t.delete, test.fn_in);
+delete_check(t.delete, test.fn_out);
+
+%% Print
+src_test_result_print(t, 'Frequency response', 'FR', test.ph);
+
+end
+
+function [fail, thdnf] = thdnf_test(t)
+
+%% Reference: AES17 6.3.2 THD+N ratio vs. frequency
+test = test_defaults_src(t);
+
+prm = src_param(t.fs1, t.fs2, test.coef_bits);
+test.f_start = 20;
+test.f_end = prm.c_pb*min(t.fs1, t.fs2);
+test.fu = prm.c_pb*min(t.fs1, t.fs2);
+%test.f_end = 0.4535*min(t.fs1, t.fs2);
+%test.fu = 0.4535*min(t.fs1, t.fs2);
+
+%% Create input file
+test = thdnf_test_input(test);
+
+%% Run test
+test = test_run_src(test, t);
+
+%% Measure
+test.fs = t.fs2;
+test.thdnf_max = t.thdnf_db_max;
+test = thdnf_test_measure(test);
+thdnf = max(max(test.thdnf));
+fail = test.fail;
+delete_check(t.delete, test.fn_in);
+delete_check(t.delete, test.fn_out);
+
+%% Print
+src_test_result_print(t, 'THD+N ratio vs. frequency', 'THDNF');
+
+end
+
+function [fail, dr_db] = dr_test(t)
+
+%% Reference: AES17 6.4.1 Dynamic range
+test = test_defaults_src(t);
+test.dr_db_min = t.dr_db_min;
+
+%% Create input file
+test = dr_test_input(test);
+
+%% Run test
+test = test_run_src(test, t);
+
+%% Measure
+test.fs = t.fs2;
+test = dr_test_measure(test);
+
+%% Get output parameters
+fail = test.fail;
+dr_db = test.dr_db;
+delete_check(t.delete, test.fn_in);
+delete_check(t.delete, test.fn_out);
+
+end
+
+
+function [fail, aap_db] = aap_test(t)
+
+%% Reference: AES17 6.6.6 Attenuation of alias products
+test = test_defaults_src(t);
+test.aap_max = t.aap_db_max;
+
+if t.fs1 <= t.fs2
+        %% Internal rate must be lower than input
+        fail = -2;
+        aap_db = NaN;
+        return;
+end
+
+test.f_start = 0.5*t.fs1;
+test.f_end = 0.5*t.fs2;
+
+%% Create input file
+test = aap_test_input(test);
+
+%% Run test
+test = test_run_src(test, t);
+
+%% Measure
+test.fs = t.fs2;
+test = aap_test_measure(test);
+aap_db = test.aap;
+fail = test.fail;
+delete_check(t.delete, test.fn_in);
+delete_check(t.delete, test.fn_out);
+
+%% Print
+src_test_result_print(t, 'Attenuation of alias products', 'AAP');
+
+end
+
+function [fail, aip_db] = aip_test(t)
+
+%% Reference: AES17 6.6.7 Attenuation of image products
+test = test_defaults_src(t);
+test.aip_max = t.aip_db_max;
+if t.fs1 >= t.fs2
+        %% Internal rate must be higher than input
+        fail = -2;
+        aip_db = NaN;
+        return;
+%%
+end
+
+%% Create input file
+test.f_end = t.fs1/2;
+test = aip_test_input(test);
+
+%% Run test
+test = test_run_src(test, t);
+
+%% Measure
+test.fs = t.fs2;
+test = aip_test_measure(test);
+aip_db = test.aip;
+fail = test.fail;
+delete_check(t.delete, test.fn_in);
+delete_check(t.delete, test.fn_out);
+
+%% Print
+src_test_result_print(t, 'Attenuation of image products', 'AIP');
+
+end
+
+%% Chirp spectrogram test. This is a visual check only. Aliasing is visible
+%  in the plot as additional freqiencies than main linear up sweep. The aliasing
+%  can be a line, few lines, or lattice pattern depending the SRC conversion
+%  to test. The main sweep line should be steady level and extend from near
+%  zero freqeuncy to near Nyquist (Fs/2).
+
+function fail = chirp_test(t)
+
+fprintf('Spectrogram test %d -> %d ...\n', t.fs1, t.fs2);
+
+%% Create input file
+test = test_defaults_src(t);
+test = chirp_test_input(test);
+
+%% Run test
+test = test_run_src(test, t);
+
+%% Analyze
+test.fs = t.fs2;
+test = chirp_test_analyze(test);
+src_test_result_print(t, 'Chirp', 'chirpf');
+
+% Delete files unless e.g. debugging and need data to run
+delete_check(t.delete, test.fn_in);
+delete_check(t.delete, test.fn_out);
+
+fail = test.fail;
+end
+
+
+%% Some SRC test specific utility functions
+%%
+
+function test = test_defaults_src(t)
+test.fmt = t.fmt;
+test.bits_in = t.bits_in;
+test.bits_out = t.bits_out;
+test.nch = t.nch;
+test.ch = t.ch;
+test.fs = t.fs1;
+test.fs1 = t.fs1;
+test.fs2 = t.fs2;
+test.mask_f = [];
+test.mask_lo = [];
+test.mask_hi = [];
+test.coef_bits = 24; % No need to use actual word length in test
+test.visible = t.visible;
+end
+
+function test = test_run_src(test, t)
+test.ex = './src_run.sh';
+test.arg = { num2str(t.bits_in), num2str(t.bits_out), num2str(t.fs1), num2str(t.fs2), test.fn_in, test.fn_out};
+delete_check(1, test.fn_out);
+test = test_run(test);
+end
+
+function src_test_result_print(t, testverbose, testacronym, ph)
+tstr = sprintf('%s SRC %d, %d', testverbose, t.fs1, t.fs2);
+if nargin > 3
+        title(ph, tstr);
+else
+        title(tstr);
+end
+pfn = sprintf('plots/%s_src_%d_%d.png', testacronym, t.fs1, t.fs2);
+print(pfn, '-dpng');
+if t.close_plot_windows
+	close all;
+end
+end
+
+%% The next are results printing functions
+
+function  print_val(fn, fs_in_list, fs_out_list, val, pf, valstr)
+n_fsi = length(fs_in_list);
+n_fso = length(fs_out_list);
+fh = fopen(fn,'w');
+fprintf(fh,'\n');
+fprintf(fh,'SRC test result: %s\n', valstr);
+fprintf(fh,'%8s, ', 'in \ out');
+for a = 1:n_fso-1
+        fprintf(fh,'%8.1f, ', fs_out_list(a)/1e3);
+end
+fprintf(fh,'%8.1f', fs_out_list(n_fso)/1e3);
+fprintf(fh,'\n');
+for a = 1:n_fsi
+        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
+	for b = 1:n_fso
+                if pf(a,b,1) < 0
+                        cstr = 'x';
+                else
+                        if isnan(val(a,b))
+                                cstr = '-';
+                        else
+                                cstr = sprintf('%8.2f', val(a,b));
+                        end
+                end
+                if b < n_fso
+                        fprintf(fh,'%8s, ', cstr);
+                else
+                        fprintf(fh,'%8s', cstr);
+                end
+        end
+        fprintf(fh,'\n');
+end
+fclose(fh);
+type(fn);
+end
+
+function print_fr(fn, fs_in_list, fs_out_list, fr_db, fr_hz, pf)
+n_fsi = length(fs_in_list);
+n_fso = length(fs_out_list);
+fh = fopen(fn,'w');
+fprintf(fh,'\n');
+fprintf(fh,'SRC test result: Frequency response +/- X.XX dB (YY.Y kHz) \n');
+fprintf(fh,'%8s, ', 'in \ out');
+for a = 1:n_fso-1
+        fprintf(fh,'%12.1f, ', fs_out_list(a)/1e3);
+end
+fprintf(fh,'%12.1f', fs_out_list(n_fso)/1e3);
+fprintf(fh,'\n');
+for a = 1:n_fsi
+        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
+	for b = 1:n_fso
+                if pf(a,b,1) < 0
+                        cstr = 'x';
+                else
+                        cstr = sprintf('%4.2f (%4.1f)', fr_db(a,b), fr_hz(a,b,2)/1e3);
+                end
+                if b < n_fso
+                        fprintf(fh,'%12s, ', cstr);
+                else
+                        fprintf(fh,'%12s', cstr);
+                end
+        end
+        fprintf(fh,'\n');
+end
+fclose(fh);
+type(fn);
+end
+
+function print_fr3db(fn, fs_in_list, fs_out_list, fr3db_hz, pf)
+n_fsi = length(fs_in_list);
+n_fso = length(fs_out_list);
+fh = fopen(fn,'w');
+fprintf(fh,'\n');
+fprintf(fh,'SRC test result: Frequency response -3dB 0 - X.XX kHz\n');
+fprintf(fh,'%8s, ', 'in \ out');
+for a = 1:n_fso-1
+        fprintf(fh,'%8.1f, ', fs_out_list(a)/1e3);
+end
+fprintf(fh,'%8.1f', fs_out_list(n_fso)/1e3);
+fprintf(fh,'\n');
+for a = 1:n_fsi
+        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
+	for b = 1:n_fso
+                if pf(a,b,1) < 0
+                        cstr = 'x';
+                else
+                        cstr = sprintf('%4.1f', fr3db_hz(a,b)/1e3);
+                end
+                if b < n_fso
+                        fprintf(fh,'%8s, ', cstr);
+                else
+                        fprintf(fh,'%8s', cstr);
+                end
+        end
+        fprintf(fh,'\n');
+end
+fclose(fh);
+type(fn);
+end
+
+
+function print_pf(fn, fs_in_list, fs_out_list, pf)
+n_fsi = length(fs_in_list);
+n_fso = length(fs_out_list);
+fh = fopen(fn,'w');
+fprintf(fh,'\n');
+fprintf(fh,'SRC test result: Fails\n');
+fprintf(fh,'%8s, ', 'in \ out');
+for a = 1:n_fso-1
+        fprintf(fh,'%14.1f, ', fs_out_list(a)/1e3);
+end
+fprintf(fh,'%14.1f', fs_out_list(n_fso)/1e3);
+fprintf(fh,'\n');
+spf = size(pf);
+npf = spf(3);
+for a = 1:n_fsi
+        fprintf(fh,'%8.1f, ', fs_in_list(a)/1e3);
+	for b = 1:n_fso
+                if pf(a,b,1) < 0
+                        cstr = 'x';
+                else
+                        cstr = sprintf('%d', pf(a,b,1));
+                        for n=2:npf
+                                if pf(a,b,n) < 0
+                                        cstr = sprintf('%s/x', cstr);
+                                else
+                                        cstr = sprintf('%s/%d', cstr,pf(a,b,n));
+                                end
+                        end
+                end
+                if b < n_fso
+                        fprintf(fh,'%14s, ', cstr);
+                else
+                        fprintf(fh,'%14s', cstr);
+                end
+        end
+        fprintf(fh,'\n');
+end
+fclose(fh);
+type(fn);
+end

--- a/test/src_test.sh
+++ b/test/src_test.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Copyright (c) 2017, Intel Corporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of the Intel Corporation nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+#
+
+octave --no-gui src_test_top.m
+if [ $? -eq 0 ]; then
+    echo "Test passed."
+    exit 0
+else
+    echo "Test failed." >&2
+    exit 1
+fi

--- a/test/src_test_top.m
+++ b/test/src_test_top.m
@@ -1,0 +1,42 @@
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+[n_fail, n_pass] = src_test(24, 24);
+if n_fail > 0 || n_pass < 1
+	fprintf('Error: SRC test with 24 bits data failed.\n');
+        quit(1)
+end
+[n_fail, n_pass] = src_test(32, 32);
+if n_fail > 0 || n_pass < 1
+	fprintf('Error: SRC test with 32 bits data failed.\n');
+        quit(1)
+end
+
+fprintf('Success: SRC test with 24 and 32 bits data passed.\n');

--- a/test/std_utils/aap_test_input.m
+++ b/test/std_utils/aap_test_input.m
@@ -1,0 +1,103 @@
+function test = aap_test_input(test)
+
+%% t = aap_test_input(t)
+%
+% Create frequency sweep data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.f_start   - start frequency
+% t.f_end     - end frequency
+% t.fs        - sample rate
+% t.bits_in   - number of bits in signal
+% t.ch        - mix test signal to channel ch
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - created input file name
+% t.fn_out    - proposed output file name for captured output
+% t.f         - frequencies in sweep
+% t.nf        - number of frequencies
+% t.tl        - tone length in seconds
+% t.ts        - tone start times
+% t.tr        - tone gain ramp length in seconds
+% t.ti        - ignore time from tone start and end, must be ti > tr
+% t.a         - tone amplitude (lin)
+% t.a_db      - tone amplitude (dB)
+% t.mark_t    - length of marker tone in seconds
+% t.mark_a    - amplitude max of marker tone (lin)
+% t.mark_a_db - amplitude max of marker tone (dB)
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.6.6 Attenuation of alias products
+%  http://www.aes.org/publications/standards/
+
+if nargin < 1
+        error('This function must be called with argunment.');
+end
+
+if test.ch == 0
+        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+end
+
+fprintf('Using parameters Fstart=%d Hz, Fend=%d Hz, Fs=%.1f kHz, bits_in=%d, ch=%d, nch=%d\n', ...
+        test.f_start, test.f_end, test.fs, test.bits_in, test.ch, test.nch);
+
+
+test.fn_in = sprintf('aap_test_in.%s', test.fmt);
+test.fn_out = sprintf('aap_test_out.%s', test.fmt);
+f_first = 997;
+f_max = max(test.f_start, test.f_end);
+f_min = min(test.f_start, test.f_end);
+n_third = ceil(log(f_max/f_min)/log(2)*3); % max 1/3 octave step
+steps = max(n_third, 50); % Min 50 steps
+test.f = [f_first logspace(log10(test.f_start), log10(test.f_end), steps) ];
+
+%% Tone sweep parameters
+test.is = 20e-3; % Ignore signal from tone start
+test.ie = 20e-3; % Ignore signal from tone end
+test.tr = 10e-3; % Gain ramp time for tones
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.3; % Error if marker positions delta is greater than 0.3s
+test.tc = 20; % Min. 20 cycles of sine wave for a frequency
+t_min = 0.2;
+test.a_db = -20;
+test.a = 10^(test.a_db/20);
+% Use t_min or min cycles count as tone length
+test.tl = max(test.tc*1/min(test.f),t_min);
+
+%% Mix the input file for test and write output
+test = mix_sweep(test);
+
+end

--- a/test/std_utils/aap_test_measure.m
+++ b/test/std_utils/aap_test_measure.m
@@ -1,0 +1,77 @@
+function test = aap_test_measure(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.6.6 Attenuation of alias products
+%  http://www.aes.org/publications/standards/
+
+%% Load output file
+[x, nx] = load_test_output(test);
+if nx == 0
+        test.fail = 1;
+        return
+end
+
+%% Find sync
+[d, nt, nt_use, nt_skip] = find_test_signal(x, test);
+
+%% Measure
+win = hamming(nt_use);
+m0 = zeros(test.nf,1);
+for n=1:test.nf
+        fprintf('Measuring %.0f Hz ...\n', test.f(n));
+        i1 = d+(n-1)*nt+nt_skip;
+        i2 = i1+nt_use-1;
+        m0(n) = level_dbfs(x(i1:i2).*win);
+end
+
+%% Calculate levels relative to first 997 Hz frequency,
+% remove it from result, sort to ascinding order for plot
+m_ref = m0(1);
+test.m = m0(2:end)-m0(1);
+[test.f, idx] = sort(test.f(2:end));
+test.m = test.m(idx);
+test.aap = max(test.m); % Worst-case
+
+if test.aap > test.aap_max
+        test.fail = 1;
+else
+        test.fail = 0;
+end
+
+test.fh = figure('visible', test.visible);
+semilogx(test.f, test.m);
+grid on;
+xlabel('Frequency (Hz)');
+ylabel('Relative level (dB)');
+grid on;
+
+end

--- a/test/std_utils/aip_test_input.m
+++ b/test/std_utils/aip_test_input.m
@@ -1,0 +1,101 @@
+function test = aip_test_input(test)
+
+%% t = aap_test_input(t)
+%
+% Create frequency sweep data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.f_start   - start frequency
+% t.f_end     - end frequency
+% t.fs        - sample rate
+% t.bits_in   - number of bits in signal
+% t.ch        - mix test signal to channel ch
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - created input file name
+% t.fn_out    - proposed output file name for captured output
+% t.f         - frequencies in sweep
+% t.nf        - number of frequencies
+% t.tl        - tone length in seconds
+% t.ts        - tone start times
+% t.tr        - tone gain ramp length in seconds
+% t.ti        - ignore time from tone start and end, must be ti > tr
+% t.a         - tone amplitude (lin)
+% t.a_db      - tone amplitude (dB)
+% t.mark_t    - length of marker tone in seconds
+% t.mark_a    - amplitude max of marker tone (lin)
+% t.mark_a_db - amplitude max of marker tone (dB)
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.6.7 Attenuation of image products
+%  http://www.aes.org/publications/standards/
+
+if nargin < 1
+        error('This function must be called with argument.');
+end
+
+if test.ch == 0
+        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+end
+
+fprintf('Using parameters Fend=%d Hz, Fs=%.1f kHz, bits_in=%d, ch=%d, nch=%d\n', ...
+        test.f_end, test.fs, test.bits_in, test.ch, test.nch);
+
+test.fn_in = sprintf('aip_test_in.%s', test.fmt);
+test.fn_out = sprintf('aip_test_out.%s', test.fmt);
+f_first = 997;
+test.f_start = 20;
+f_min = min(test.f_start, test.f_end);
+f_max = max(test.f_start, test.f_end);
+test.fu = f_max;
+n_thirdoct = ceil(log(f_max/f_min)/log(2)*3); % max 1/3 octave step
+steps = n_thirdoct;
+test.f = [f_first logspace(log10(test.f_start), log10(test.f_end), steps) ];
+
+%% Tone sweep parameters
+test.is = 20e-3; % Ignore signal from tone start
+test.ie = 20e-3; % Ignore signal from tone end
+test.tr = 10e-3; % Gain ramp time for tones
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.1; % Error if marker positions delta is greater than 0.1s
+test.tl = 3;
+test.a_db = -20;
+test.a = 10^(test.a_db/20);
+
+%% Mix the input file for test and write output
+test = mix_sweep(test);
+
+end

--- a/test/std_utils/aip_test_measure.m
+++ b/test/std_utils/aip_test_measure.m
@@ -1,0 +1,84 @@
+function test = aip_test_measure(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.6.7 Attenuation of image products
+%  http://www.aes.org/publications/standards/
+
+%% Load output file
+[x, nx] = load_test_output(test);
+if nx == 0
+        test.g_db = NaN;
+        test.fail = 1;
+        return
+end
+
+%% Find sync
+[d, nt, nt_use, nt_skip] = find_test_signal(x, test);
+
+%% Measure all test frequencies
+t_skip = 1.0;
+ml = zeros(test.nf,1);
+mn = zeros(test.nf,1);
+b_lpf = stdlpf_get(test.fu, test.fs); % Get LPF coef
+b_hpf = stdhpf_get(test.fu, test.fs); % Get HPF coef
+for n=1:test.nf
+        fprintf('Measuring %.0f Hz ...\n', test.f(n));
+        % Get notch coef for this frequency
+        [b_notch, a_notch] = stdnotch_get(test.f(n), test.fs);
+        i1 = d+(n-1)*nt+nt_skip;
+        i2 = i1+nt_use-1;
+        x_lpf = filter(b_lpf, 1, x(i1:i2)); % Standard LPF, need for 997 Hz only
+        x_notch = filter(b_notch, a_notch, x(i1:i2)); % Standard notch
+        x_hpf = filter(b_hpf, 1, x_notch); % Standard HPF
+        ml(n) = level_dbfs(x_lpf(round(t_skip*test.fs):end));
+        mn(n) = level_dbfs(x_hpf(round(t_skip*test.fs):end));
+end
+
+%% Calculate levels relative to first 997 Hz frequency,
+% remove it from result, sort to ascinding order for plot
+test.f = test.f(2:end);
+test.m = mn(2:end)-ml(1);
+test.aip = max(test.m); % Worst-case
+if test.aip > test.aip_max
+        test.fail = 1;
+else
+        test.fail = 0;
+end
+
+test.fh = figure('visible', test.visible);
+semilogx(test.f, test.m);
+grid on;
+xlabel('Frequency (Hz)');
+ylabel('Relative level (dB)');
+grid on;
+
+end

--- a/test/std_utils/dr_test_input.m
+++ b/test/std_utils/dr_test_input.m
@@ -1,0 +1,91 @@
+function test = dr_test_input(test)
+
+%% t = dr_test_input(t)
+%
+% Create tone data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.fs        - sample rate
+% t.bits_in   - signal word length
+% t.ch        - mix test signal to channel ch
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - created input file name
+% t.fn_out    - proposed output file name for captured output
+% t.f         - test signal frequency
+% t.tl        - tone length in seconds
+% t.ts        - tone start time
+% t.tr        - tone gain ramp length in seconds
+% t.ti        - ignore time from tone start and end, must be ti > tr
+% t.a         - tone amplitude (lin)
+% t.a_db      - tone amplitude (dB)
+% t.mark_t    - length of marker tone in seconds
+% t.mark_a    - amplitude max of marker tone (lin)
+% t.mark_a_db - amplitude max of marker tone (dB)
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.2.3 Frequency response
+
+if nargin < 1
+        fprintf('Warning, using default parameters!\n');
+        test.fs = 48e3; test.bits_in=32; test.ch=1; test.nch=1;
+end
+
+if test.ch == 0
+        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+end
+
+fprintf('Using parameters Fs=%.1f, bits=%d, ch=%d, Nch=%d\n', ...
+        test.fs/1e3, test.bits_in, test.ch, test.nch );
+
+%% Test tone parameters
+test.fn_in = sprintf('dr_test_in.%s', test.fmt);
+test.fn_out = sprintf('dr_test_out.%s', test.fmt);
+test.f = 997;
+test.a_db = -60;
+test.a = 10^(test.a_db/20);
+test.is = 1.0; % Ignore signal from tone start
+test.ie = 20e-3; % Ignore signal from tone end
+test.tr = 10e-3; % Gain ramp time for tones
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.3; % Error if marker positions delta is greater than 0.3s
+test.tc = 25; % Min. 20 cycles of sine wave for a frequency
+test.tl = 3;  % 3 seconds tone
+
+%% Mix the input file for test and write output
+test = mix_sweep(test);
+
+end

--- a/test/std_utils/dr_test_measure.m
+++ b/test/std_utils/dr_test_measure.m
@@ -1,0 +1,76 @@
+function test = dr_test_measure(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Load output file
+[x, nx] = load_test_output(test);
+if nx == 0
+        test.dr_db = NaN;
+        test.fail = 1;
+        return
+end
+
+%% Find sync
+[d, nt, nt_use, nt_skip] = find_test_signal(x, test);
+
+%% Notch filter
+y0n = stdnotch(x, test.f, test.fs);
+
+%% CCIR-RMS weighting filter
+y0w = stdweight(y0n, test.fs);
+
+%% Trim sample by removing first 1s to let the notch to apply
+i1 = d+nt_skip;
+i2 = i1+nt_use-1;
+y = x(i1:i2);
+y_n = y0w(i1:i2);
+
+%% Gain, SNR
+level_in = test.a_db;
+level_out = level_dbfs(y);
+level_final = level_dbfs(y_n);
+test.dr_db = level_out-level_final-test.a_db;
+fprintf('DR = %5.1f dB\n', test.dr_db);
+if 0
+        plot(y);
+        hold on
+        plot(y_n,'g');
+        hold off
+end
+
+%% Check pass/fail
+test.fail = 0;
+if test.dr_db < test.dr_db_min
+        fprintf('Failed DR %f dB (min %f dB)\n', test.dr_db, test.dr_db_min);
+        test.fail = 1;
+end
+
+end

--- a/test/std_utils/fr_test_input.m
+++ b/test/std_utils/fr_test_input.m
@@ -1,0 +1,123 @@
+function test = fr_test_input(test)
+
+%% t = fr_test_input(t)
+%
+% Create frequency sweep data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.f_max     - maximum frequency of sweep, set e.g. to 0.99*fs/2
+% t.fs        - sample rate
+% t.bits_in   - number of bits in signal
+% t.ch        - mix test signal to channel ch, e.g. set to [1 2] to measure
+%               two channels
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - Created input file name
+% t.fn_out    - Proposed output file name for captured output
+% t.f_ref     - Reference frequency used to report deviation (997 Hz)
+% t.f_min     - Sweep start frequency
+% t.f         - Frequencies in sweep
+% t.is        - Ignore signal from tone start
+% t.ie        - Ignore signal from tone end
+% t.tr        - tone gain ramp length in seconds
+% t.sm        - Seek start marker this time length from start
+% t.em        - Seek end marker this time length from end
+% t.mt        - Error if marker positions delta is greater than this
+% t.tc        - Min cycles of sine wave per frequency
+% t.tl        - Tone length in seconds
+% t.a_db      - Tone amplitude (dB)
+% t.a         - Tone amplitude (lin)
+% t.nt        - Number of samples per tone
+% t.nf        - Number of frequencies
+% t.na        - Number of amplitudes
+% t.mark_t    - Length of marker tone in seconds
+% t.mark_a    - Amplitude max of marker tone (lin)
+% t.mark_a_db - Amplitude max of marker tone (dB)
+% t.ts        - Tone start times
+%
+% E.g.
+% t.fs=48e3; t.f_max=20e3; t.bits_in=16; t.ch=1; t.nch=2; t = fr_test_input(t);
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.2.3 Frequency response
+%  http://www.aes.org/publications/standards/
+
+if nargin < 1
+        fprintf('Warning, using default parameters!\n');
+        test.fs = 48e3; test.f_max = 0.99*test.fs/2; test.ch=1; test.nch=1;
+        test.bits_in=32;
+end
+
+if test.ch == 0
+        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+end
+
+fprintf('Using parameters Fmax=%.1f kHz, Fs=%.1f, ch=%d, Nch=%d, bits_in=%d\n', ...
+        test.f_max/1e3, test.fs/1e3, test.ch, test.nch, test.bits_in);
+
+test.fn_in = sprintf('fr_test_in.%s', test.fmt);
+test.fn_out =  sprintf('fr_test_out.%s', test.fmt);
+test.f_ref = 997;
+test.f_min = 20;
+
+%% Use a dense frequency grid to see -3 dB point well
+n_oct = ceil(log(test.f_max/test.f_ref)/log(2)*35);
+f = logspace(log10(test.f_ref), log10(test.f_max), n_oct);
+c = f(1)/f(2);
+f_next = test.f_ref*c;
+while (f_next > test.f_min)
+        f = [f_next f];
+        f_next = f_next*c;
+end
+test.f = f;
+
+%% Tone sweep parameters
+test.is = 20e-3; % Ignore signal from tone start
+test.ie = 20e-3; % Ignore signal from tone end
+test.tr = 10e-3; % Gain ramp time for tones
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.1; % Error if marker positions delta is greater than 0.1s
+test.tc = 10; % Min. 10 cycles of sine wave for a frequency
+t_min = 0.2;
+% Use t_min or min cycles count as tone length
+test.tl = max(test.tc*1/min(f),t_min);
+test.a_db = -20;
+test.a = 10.^(test.a_db/20);
+
+%% Mix the input file for test and write output
+test = mix_sweep(test);
+
+end

--- a/test/std_utils/fr_test_measure.m
+++ b/test/std_utils/fr_test_measure.m
@@ -1,0 +1,173 @@
+function test = fr_test_measure(test)
+
+%% t = fr_test_measure(t)
+%
+% Measure frequency response from captured frequency sweep created by
+% fr_test_input() that sets most of the input struct fiels. The output
+% is read from file t.fn_out.
+%
+% Input parameters
+% t.f_lo    - Measure ripple start frequency
+% t.f_hi    - Measure ripple end frequency
+% t.rp_max  - Max. ripple +/- dB
+% t.mask_f  - Frequencies for mask
+% t.mask_lo - Upper limits of mask
+% t.mask_hi - Lower limits of mask
+%
+% Output parameters
+% t.m           - Measured frequency response
+% t.rp          - Measured ripple +/- dB
+% t.fr3db_hz    - Bandwidth in Hz for -3 dB attenuated response
+% t.fail        - Returns zero for passed
+% t.fh          - Figure handle
+% t.ph          - Plot handle
+%
+% E.g.
+% t.fs=48e3; t.f_max=20e3; t.bits_out=16; t.ch=1; t.nch=2; t=fr_test_input(t);
+% t.fn_out=t.fn_in; t.f_lo=20; t.f_hi=20e3; t.rp_max=[]; t.mask_f=[];
+% t=fr_test_measure(t);
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.2.3 Frequency response
+%  http://www.aes.org/publications/standards/
+
+[x, nx] = load_test_output(test);
+
+j = 1;
+for channel = test.ch
+
+        if nx == 0
+                test.rp(j) = NaN;
+                test.fr3db_hz(j) = NaN;
+                test.fail = 1;
+                return
+        end
+
+        %% Find sync
+        [d, nt, nt_use, nt_skip] = find_test_signal(x(:,j), test);
+
+        win = hamming(nt_use);
+        m0 = zeros(test.nf,1);
+        for n=1:test.nf
+                fprintf('Measuring %.0f Hz ...\n', test.f(n));
+                i1 = d+(n-1)*nt+nt_skip;
+                i2 = i1+nt_use-1;
+                m0(n) = level_dbfs(x(i1:i2,j).*win) -test.a_db;
+        end
+
+        %% Scale 997 Hz point as 0 dB
+        df = test.f - test.f_ref;
+        [~,i997] = min(abs(df));
+        m_offs = m0(i997);
+        test.m(:,j) = m0 - m_offs;
+
+        %% Check pass/fail
+        idx0 = find(test.f < test.f_hi);
+        idx1 = find(test.f(idx0) > test.f_lo);
+        range_db = max(test.m(idx1,j))-min(test.m(idx1,j));
+        test.rp(j) = range_db/2;
+        test.fail = 0;
+        if ~isempty(test.rp_max)
+                if test.rp > test.rp_max
+                        fprintf('Failed response +/- %f dBpp (max +/- %f dB)\n', ...
+                                test.rp, test.rp_max);
+                        test.fail = 1;
+                end
+        end
+
+        %% Find frequency response 3 dB 0-X Hz
+        idx3 = find(test.m(:,j) > -3);
+        test.fr3db_hz(j) = test.f(idx3(end));
+
+        %% Interpolate mask in logaritmic frequencies, check
+        if ~isempty(test.mask_f)
+                f_log = log(test.f);
+                mask_hi = interp1(log(test.mask_f), test.mask_hi(:,j), ...
+                        f_log, 'linear');
+                mask_lo = interp1(log(test.mask_f), test.mask_lo(:,j), ...
+                        f_log, 'linear');
+                over_mask = test.m(:,j)-mask_hi';
+                under_mask = mask_lo'-test.m(:,j);
+                idx = find(isnan(over_mask) == 0);
+                [m_over_mask, io] = max(over_mask(idx));
+                idx = find(isnan(under_mask) == 0);
+                [m_under_mask, iu] = max(under_mask(idx));
+                if m_over_mask > 0
+                        fprintf('Failed upper response mask around %.0f Hz\n', ...
+                                test.f(io));
+                        test.fail = 1;
+                end
+                if m_under_mask > 0
+                        fprintf('Failed lower response mask around %.0f Hz\n', ...
+                                test.f(iu));
+                        test.fail = 1;
+                end
+        end
+
+        test.fh(j) = figure('visible', test.visible);
+        subplot(1,1,1);
+        test.ph(j) = subplot(1,1,1);
+        %semilogx(test.f, test.m(:,j));
+        plot(test.f, test.m(:,j));
+        grid on;
+        xlabel('Frequency (Hz)');
+        ylabel('Magnitude (dB)');
+        if length(test.mask_f) > 0
+                hold on;
+                plot(test.f, mask_hi, 'r--');
+                plot(test.f, mask_lo, 'r--');
+                hold off;
+        end
+	ax = axis();
+	axis([ax(1:2) -4 1]);
+        if max(max(test.m(idx1,j))-min(test.m(idx1,j))) < 1
+                axes('Position', [ 0.2 0.2 0.4 0.2]);
+                box on;
+                plot(test.f(idx1), test.m(idx1,j));
+                if ~isempty(test.rp_max)
+                        hold on;
+                        plot([test.f_lo test.f_hi], ...
+                                [-test.rp_max/2 -test.rp_max/2], 'r--');
+                        plot([test.f_lo test.f_hi], ...
+                                [ test.rp_max/2  test.rp_max/2], 'r--');
+                        hold off;
+                end
+                grid on;
+                axis([0 test.f_hi -0.1 0.1]);
+        end
+
+        %% Next channel to measure
+        j=j+1;
+end
+
+end

--- a/test/std_utils/g_test_input.m
+++ b/test/std_utils/g_test_input.m
@@ -1,0 +1,97 @@
+function test = g_test_input(test)
+
+%% t = dr_test_input(t)
+%
+% Create tone data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.fs        - sample rate
+% t.bits_in   - signal word length
+% t.ch        - mix test signal to channel ch
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - created input file name
+% t.fn_out    - proposed output file name for captured output
+% t.f         - test signal frequency
+% t.tl        - tone length in seconds
+% t.ts        - tone start time
+% t.tr        - tone gain ramp length in seconds
+% t.ti        - ignore time from tone start and end, must be ti > tr
+% t.a         - tone amplitude (lin)
+% t.a_db      - tone amplitude (dB)
+% t.mark_t    - length of marker tone in seconds
+% t.mark_a    - amplitude max of marker tone (lin)
+% t.mark_a_db - amplitude max of marker tone (dB)
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.2.2 Gain
+%  http://www.aes.org/publications/standards/
+
+
+if nargin < 1
+        fprintf('Warning, using default parameters!\n');
+        test.fs = 48e3; test.bits=32; test.ch=1; test.nch=1;
+end
+
+if test.ch == 0
+        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+end
+
+fprintf('Using parameters Fs=%.1f, bits_in=%d', test.fs/1e3, test.bits_in);
+fprintf(', ch=%d', test.ch );
+fprintf(', Nch=%d\n', test.nch );
+
+test.fn_in = sprintf('g_test_in.%s', test.fmt);
+test.fn_out = sprintf('g_test_out.%s', test.fmt);
+test.f = 997;
+
+
+%% Tone sweep parameters
+test.is = 20e-3; % Ignore signal from tone start
+test.ie = 20e-3; % Ignore signal from tone end
+test.tr = 10e-3; % Gain ramp time for tones
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.3; % Error if marker positions delta is greater than 0.3s
+test.tc = 25; % Min. 20 cycles of sine wave for a frequency
+test.a_db = -20; % -20 dBFS level
+test.a = 10^(test.a_db/20);
+% 0.5 seconds tone, this will be adjusted to be integer number of samples
+test.tl = 0.5;
+
+%% Mix the input file for test and write output
+test = mix_sweep(test);
+
+end

--- a/test/std_utils/g_test_measure.m
+++ b/test/std_utils/g_test_measure.m
@@ -1,0 +1,70 @@
+function test = g_test_measure(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.2.2 Gain
+%  http://www.aes.org/publications/standards/
+
+%% Load output file
+[x, nx] = load_test_output(test);
+
+if nx == 0
+        test.g_db = NaN;
+        test.fail = 1;
+        return
+end
+
+%% Standard low-pass
+y0 = stdlpf(x, test.fu, test.fs);
+
+%% Find sync
+[d, nt, nt_use, nt_skip] = find_test_signal(y0, test);
+
+%% Trim sample by removing first 1s to let the notch to apply
+i1 = d+nt_skip;
+i2 = i1+nt_use-1;
+y = y0(i1:i2);
+
+%% Gain, SNR
+level_in = test.a_db;
+level_out = level_dbfs(y);
+test.g_db = level_out-level_in;
+fprintf('Gain = %6.3f dB (expecting %6.3f dB)\n', test.g_db, test.g_db_expect);
+
+%% Check pass/fail
+test.fail = 0;
+if abs(test.g_db_expect-test.g_db) > test.g_db_tol
+        fprintf('Failed gain %f dB (max %f dB)\n', test.g_db, test.g_db_tol);
+        test.fail = 1;
+end
+
+end
+

--- a/test/std_utils/level_dbfs.m
+++ b/test/std_utils/level_dbfs.m
@@ -1,0 +1,46 @@
+function dbfs = level_dbfs(x)
+
+%% dbfs = level_dbfs(x)
+%
+% Input
+% x - signal
+%
+% Output
+% dbfs - sigmal level in dBFS
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference AES 17 3.12.3
+level_ms = mean(x.^2);
+dbfs = 10*log10(level_ms) + 20*log10(sqrt(2));
+
+end

--- a/test/std_utils/stdhpf.m
+++ b/test/std_utils/stdhpf.m
@@ -1,0 +1,54 @@
+function y = stdhpf(x, fu, fs)
+
+%% y = stdhpf(x, fu, fs)
+%
+% Standard high-pass filter
+%
+% Input
+% x - input signal
+% fu - upper band-edge frequency
+% fs - sample rate
+%
+% Output
+% y - filtered signal
+%
+% Reference AES17 5.2.6
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Design filter
+b = stdhpf_get(fu, fs);
+
+%% Filter
+y = filter(b, 1, x);
+
+
+end

--- a/test/std_utils/stdhpf_get.m
+++ b/test/std_utils/stdhpf_get.m
@@ -1,0 +1,68 @@
+function b = stdhpf_get(fu, fs)
+
+%% y = stdhpf(x, fu, fs)
+%
+% Standard high-pass filter
+%
+% Input
+% x - input signal
+% fu - upper band-edge frequency
+% fs - sample rate
+%
+% Output
+% y - filtered signal
+%
+% Reference AES17 5.2.6
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Design filter
+rp = 0.5;
+rs = -50; % Some margin vs. requirement
+a = [0 1];
+fc = min(1.3*fu, 0.99*fs/2);
+f = [fu fc];
+dev = [ 10^(rs/20) (10^(rp/20)-1)/(10^(rp/20)+1) ];
+[n, wn, beta, ftype] = kaiserord(f, a, dev, fs);
+b = fir1(n, wn, ftype, kaiser(n+1,beta));
+
+if 0
+        f = linspace(0, fs/2, 1000);
+        h = freqz(b,1, f, fs);
+        figure
+        plot(f, 20*log10(abs(h)))
+        hold on;
+        plot( [0 fu], [-40 -40], 'r', [fc fs/2], [-0.5 -0.5], 'r', [fc fs/2], [0.5 0.5], 'r');
+        hold off;
+        grid on;
+end
+
+end

--- a/test/std_utils/stdlpf.m
+++ b/test/std_utils/stdlpf.m
@@ -1,0 +1,54 @@
+function y = stdlpf(x, fu, fs)
+
+%% y = stdhpf(x, fu, fs)
+%
+% Standard high-pass filter
+%
+% Input
+% x - input signal
+% fu - upper band-edge frequency
+% fs - sample rate
+%
+% Output
+% y - filtered signal
+%
+% Reference AES17 5.2.5
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Design filter
+b = stdlpf_get(fu, fs);
+
+%% Filter
+y = filter(b, 1, x);
+
+
+end

--- a/test/std_utils/stdlpf_get.m
+++ b/test/std_utils/stdlpf_get.m
@@ -1,0 +1,70 @@
+function b = stdlpf_get(fu, fs)
+
+%% b = stdlpf_get(fu, fs)
+%
+% Standard loww-pass filter
+%
+% Input
+% fu - upper band-edge frequency
+% fs - sample rate
+%
+% Output
+% b - coefficients for FIR filter
+%
+% Reference AES17 5.2.5
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Design filter
+rp = 0.001; % Since this may need to be in frequency response measurement the ripple must be very small
+rs = -65; % Some margin vs. requirement
+a = [1 0];
+% Note: The fc-fu for digital low-pass is not feasible. Use of fu*1.2 instead
+% results to example 24 kHz for 20 kHz upper band-edge. This could be a mistake
+% in specification.
+fc = min(fu*1.2, 0.99*fs/2);
+f = [fu fc];
+dev = [ (10^(rp/20)-1)/(10^(rp/20)+1) 10^(rs/20) ];
+[n, wn, beta, ftype] = kaiserord(f, a, dev, fs);
+b = fir1(n, wn, ftype, kaiser(n+1,beta));
+
+if 0
+        f = linspace(0, fs/2, 1000);
+        h = freqz(b,1, f, fs);
+        figure
+        plot(f, 20*log10(abs(h)))
+        hold on;
+        plot( [fc fs/2], [-60 -60], 'r', [0 fu], [-0.1 -0.1], 'r', [0 fu], [0.1 0.1], 'r');
+        hold off;
+        grid on;
+end
+
+end

--- a/test/std_utils/stdnotch.m
+++ b/test/std_utils/stdnotch.m
@@ -1,0 +1,47 @@
+function y = stdnotch(x, fn, fs)
+
+%% y = stdnotch(x, fn, fs)
+%
+% Input
+% x  - input signal
+% fn - notch frequency
+% fs - sample rate
+%
+% Output
+% y - filtered signal
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+[b, a] = stdnotch_get(fn, fs);
+y = filter(b, a, x);
+
+end

--- a/test/std_utils/stdnotch_get.m
+++ b/test/std_utils/stdnotch_get.m
@@ -1,0 +1,70 @@
+function [b, a] = stdnotch_get(fn, fs)
+
+%% [b, a] = stdnotch_get(fn, fs)
+%
+% Input
+% fn - notch frequency
+% fs - sample rate
+%
+% Output
+% b - coefficients for filter zeros
+% a - coefficients for filter poles
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+target_q = 2.1;
+bw = (2*fn/fs)/target_q;
+if exist('iirnotch.m') == 2
+        [b, a] = iirnotch(2*fn/fs, bw);
+else
+        [b, a] = pei_tseng_notch(2*fn/fs, bw);
+end
+if 0
+        %% In AES17 5.2.8 standard notch must have Q 1.2-3.0
+        %  Quality factor is ratio of of center frequency to
+        %  differenence between -3 dB frequencies.
+        figure;
+        f = linspace(0.2*fn, min(2*fn,fs/2), 5000);
+        h = freqz(b, a, f, fs);
+        m = 20*log10(abs(h));
+        plot(f, m); grid on;
+        idx = find(m < -3);
+        f1 = f(idx(1));
+        f2 = f(idx(end));
+        q = fn/(f2-f1);
+        if (q < 1.2) || (q > 3.0)
+                fprintf('Required Q value failed, Q = %5.2f\n', q);
+        else
+                fprintf('Q = %5.2f\n', q);
+        end
+end
+end

--- a/test/std_utils/stdweight.m
+++ b/test/std_utils/stdweight.m
@@ -1,0 +1,86 @@
+function y = stdweight(x, fs)
+
+%% y = stdweight(x, fs)
+%
+% Input
+% x  - input signal
+% fs - sample rate
+%
+% Output
+% y - filtered signal
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Frequency grid for FIR design
+f = linspace(0, fs/2, 6000);
+
+%% From https://en.wikipedia.org/wiki/ITU-R_468_noise_weighting
+h1 = -4.737338981378384e-24*f.^6 +2.043828333606125e-15*f.^4 -1.363894795463638e-7*f.^2 +1;
+h2 =  1.306612257412824e-19*f.^5 -2.118150887518656e-11*f.^3 +5.559488023498642e-4*f;
+RITU = 1.246332637532143e-4*f./sqrt(h1.^2+h2.^2);
+ITU = 18.2+20*log10(RITU)-5.63; % AES17 CCIR-RMS
+fc = [ 31.5    63   100   200   400   800  1000  2000  3150  4000  5000  6300  7100  8000  9000 10000 12500 14000 16000 20000 31500];
+ga = [-35.5 -29.5 -25.4 -19.4 -13.4  -7.5  -5.6     0   3.4   4.9   6.1   6.6   6.4   5.8   4.5   2.5  -5.6 -10.9 -17.3 -27.8 -48.3];
+tu = [  2.0   1.4   1.0  0.85  0.70  0.55  0.50  0.50  0.50  0.50  0.50  0.01  0.20  0.40  0.60  0.80   1.2   1.4   1.6   2.0   2.8];
+tl = [ -2.0  -1.4  -1.0 -0.85 -0.70 -0.55 -0.50 -0.50 -0.50 -0.50 -0.50 -0.01 -0.20 -0.40 -0.60 -0.80  -1.2  -1.4  -1.6  -2.0   NaN];
+
+%% Fine tune the 6300Hz, 6.6 dB point
+if fs > 2*6300
+        idx = find(f > 6300, 1, 'first');
+        ITU = ITU + 6.6-ITU(idx);
+else
+        idx = find(f > 3150, 1, 'first');
+        ITU = ITU + 3.4-ITU(idx);
+end
+
+m_fir = 10.^(ITU/20);
+f_fir = 2*f/fs;
+n_fir = 4000; % Sufficient up to 192 kHz
+if (fs < 96001)
+        n_fir = 2000;
+end
+if (fs < 48001)
+        n_fir = 1000;
+end
+if (fs < 16001)
+        n_fir = 400;
+end
+bz = fir2(n_fir, f_fir, m_fir);
+y = filter(bz, 1, x);
+if 0
+        h = freqz(bz, 1, f, fs);
+        my_w_db = 20*log10(abs(h));
+        figure;
+        semilogx(f,ITU,fc,ga,'x',fc,ga+tu,fc,ga+tl, f, my_w_db );
+        grid on; xlabel('Hz'); ylabel('dB');
+end
+end

--- a/test/std_utils/thdnf_test_input.m
+++ b/test/std_utils/thdnf_test_input.m
@@ -1,0 +1,95 @@
+function test = thdnf_test_input(test)
+
+%% t = dr_test_input(t)
+%
+% Create tone data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.fs        - sample rate
+% t.bits_in   - signal word length
+% t.ch        - mix test signal to channel ch
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - created input file name
+% t.fn_out    - proposed output file name for captured output
+% t.f         - test signal frequency
+% t.tl        - tone length in seconds
+% t.ts        - tone start time
+% t.tr        - tone gain ramp length in seconds
+% t.ti        - ignore time from tone start and end, must be ti > tr
+% t.a         - tone amplitude (lin)
+% t.a_db      - tone amplitude (dB)
+% t.mark_t    - length of marker tone in seconds
+% t.mark_a    - amplitude max of marker tone (lin)
+% t.mark_a_db - amplitude max of marker tone (dB)
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.3.2 THD+N ratio vs frequency
+%  http://www.aes.org/publications/standards/
+
+if nargin < 1
+        fprintf('Warning, using default parameters!\n');
+        test.fs = 48e3; test.f_start=20; test.f_end=20e3; test.bits_in=32; test.ch=1; test.nch=1;
+end
+
+if test.ch == 0
+        test.ch = 1+round(rand(1,1)*(test.nch-1)); % Test random channel 1..Nch
+end
+
+fprintf('Using parameters Fstart=%.0f Hz, Fend=%.0f Hz, Fs=%.1f Hz, bits_in=%d, ch=%d, Nch=%d\n', ...
+        test.f_start, test.f_end, test.fs/1e3, test.bits_in, test.ch, test.nch );
+
+test.fn_in = sprintf('thdnf_test_in.%s', test.fmt);
+test.fn_out = sprintf('thdnf_test_out.%s', test.fmt);
+noct = ceil(log(test.f_end/test.f_start)/log(2)); % Max 1 octave steps
+test.f = logspace(log10(test.f_start),log10(test.f_end), noct);
+
+
+%% Tone sweep parameters
+test.is = 20e-3; % Ignore signal from tone start
+test.ie = 20e-3; % Ignore signal from tone end
+test.tr = 10e-3; % Gain ramp time for tones
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.1; % Error if marker positions delta is greater than 0.1s
+test.a_db = [-1 -20]; % -1 and -20 dBFS levels
+test.a = 10.^(test.a_db/20);
+test.tl = 4; % 3 seconds tone
+test.nst = 2; % Wait 1 seconds for frequency specific notch output to settle
+
+%% Mix the input file for test and write output
+test = mix_sweep(test);
+
+end

--- a/test/std_utils/thdnf_test_measure.m
+++ b/test/std_utils/thdnf_test_measure.m
@@ -1,0 +1,83 @@
+function test = thdnf_test_measure(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Reference: AES17 6.3.2 THD+N ratio vs frequency
+%  http://www.aes.org/publications/standards/
+
+%% Load output file
+[x, nx] = load_test_output(test);
+if nx == 0
+        test.g_db = NaN;
+        test.fail = 1;
+        return
+end
+
+%% Standard low-pass
+y0 = stdlpf(x, test.fu, test.fs);
+
+%% Find sync
+[d, nt, nt_use, nt_skip] = find_test_signal(y0, test);
+
+%% Measure all test frequencies
+ml = zeros(test.nf,test.na);
+mn = zeros(test.nf,test.na);
+n_notch_settle = round(test.fs*test.nst);
+nn = 1;
+for m=1:test.na
+        for n=1:test.nf
+                fprintf('Measuring %.0f Hz ...\n', test.f(n));
+                i1 = d+(nn-1)*nt+nt_skip;
+                i2 = i1+nt_use-1;
+                nn = nn+1;
+                y0n = stdnotch(y0(i1:i2), test.f(n), test.fs);
+                ml(n,m) = level_dbfs(y0(i1:i2));
+                mn(n,m) = level_dbfs(y0n(n_notch_settle:end));
+        end
+end
+
+test.thdnf = mn - ml;
+test.thdnf_high = test.thdnf(:,1);
+test.thdnf_low = test.thdnf(:,2);
+if max(max(test.thdnf)) > test.thdnf_max
+        test.fail = 1;
+else
+        test.fail = 0;
+end
+
+test.fh = figure('visible', test.visible);
+semilogx(test.f, test.thdnf(:,1), 'b', test.f, test.thdnf(:,2), 'g--');
+grid on;
+xlabel('Frequency (Hz)');
+ylabel('THD+N (dB)');
+legend('-1 dBFS','-20 dBFS');
+
+end

--- a/test/test_utils/chirp_test_analyze.m
+++ b/test/test_utils/chirp_test_analyze.m
@@ -1,0 +1,91 @@
+function test = chirp_test_analyze(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Load output file
+[x, nx] = load_test_output(test);
+if nx < 1
+	test.fail = -1; % No data
+	return;
+end
+
+%% Find sync
+[d, nt, nt_use, nt_skip] = find_test_signal(x, test);
+
+%% Trim sample
+i1 = d+nt_skip;
+i2 = i1+nt_use-1;
+z = x(i1:i2, :);
+y = z(:,test.ch);
+s = sum(z,2);
+
+%% Quick check length, RMS, offset, and channels sum
+sz = size(z);
+tz = sz(1)/test.fs;
+et = abs(test.cl-tz)/test.cl;
+rms_db = 10*log10(mean(z.^2)) + 20*log10(sqrt(2));
+offs_db = 20*log10(abs(mean(z)));
+sum_max_db = 20*log10(max(abs(s)));
+% Check for proper ratio of out/in samples, minimum level, maximum offset
+% and maximum of sum of channels. The input is such that the channels should
+% sum to zero. A phase difference in channels would cause non-zero output
+% for channels sum. Dithered input causes a small non-zero sum value.
+
+if et > 0.05
+	fail = 1;
+	fprintf('Failed output chirp length, err=%f, t=%f.\n', et, tz);
+else if (min(rms_db) < -3) && (test.fs2 + 1 > test.fs1)
+	     fail = 1;
+	     fprintf('Failed output chirp level.\n');
+     else if max(offs_db) > -40
+		  fail = 1;
+		  fprintf('Failed output chirp DC offset.\n');
+	  else if (sum_max_db > -100) && (mod(test.nch, 2) == 0)
+		       fail = 1;
+		       fprintf('Failed output chirp channels phase.\n');
+	       else
+		       fail = 0;
+	       end
+	  end
+     end
+end
+
+test.fh = figure('visible', test.visible);
+ns = 1024;
+no = round(0.9*ns);
+specgram(y(:,1), ns, test.fs, kaiser(ns,27), no);
+colormap('jet');
+caxis([-150 0]);
+colorbar('EastOutside');
+
+test.fail = fail;
+
+end

--- a/test/test_utils/chirp_test_input.m
+++ b/test/test_utils/chirp_test_input.m
@@ -1,0 +1,96 @@
+function test = chirp_test_input(test)
+
+%% t = dr_test_input(t)
+%
+% Create tone data file for playback & record on real device or
+% for algorithm simulation.
+%
+% Input parameters
+% t.fs        - sample rate
+% t.bits_in   - signal word length
+% t.ch        - mix test signal to channel ch
+% t.nch       - total number of channels in data
+%
+% Output parameters
+% t.fn_in     - created input file name
+% t.fn_out    - proposed output file name for captured output
+% t.f         - test signal frequency
+% t.tl        - tone length in seconds
+% t.ts        - tone start time
+% t.tr        - tone gain ramp length in seconds
+% t.ti        - ignore time from tone start and end, must be ti > tr
+% t.a         - tone amplitude (lin)
+% t.a_db      - tone amplitude (dB)
+% t.mark_t    - length of marker tone in seconds
+% t.mark_a    - amplitude max of marker tone (lin)
+% t.mark_a_db - amplitude max of marker tone (dB)
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+if nargin < 1
+        fprintf('Warning, using default parameters!\n');
+        test.fs = 48e3; test.bits=32; test.ch=1; test.nch=1;
+end
+
+if test.ch == 0
+        test.ch = 1:test.nch; % Test all channels 1..Nch
+end
+
+fprintf('Using parameters Fs=%.1f, bits_in=%d', test.fs/1e3, test.bits_in);
+fprintf(', ch=%d', test.ch );
+fprintf(', Nch=%d\n', test.nch );
+
+test.fn_in = sprintf('chirp_test_in.%s', test.fmt);
+test.fn_out =  sprintf('chirp_test_out.%s', test.fmt);
+
+
+%% Chirp parameters
+test.a_db = -0.1; % Near full scale
+test.a = 10^(test.a_db/20);
+test.f_min = 20;
+test.f_max = test.fs/2;
+test.cl = 2.0;
+
+
+%% Parameters to find signal between markers
+test.nf = 1;
+test.na = 1;
+test.sm = 3; % Seek start marker from 3s from start
+test.em = 3; % Seek end marker from 3s from end
+test.mt = 0.3; % Error if marker positions delta is greater than 0.3s
+test.is = 0; % Ignore signal from tone start
+test.ie = 0; % Ignore signal from tone end
+
+%% Mix the input file for test and write output
+test = mix_chirp(test);
+
+end

--- a/test/test_utils/delete_check.m
+++ b/test/test_utils/delete_check.m
@@ -1,0 +1,35 @@
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+function delete_check(really, f)
+if really && exist(f) == 2
+        delete(f);
+end
+end

--- a/test/test_utils/dither_and_quantize.m
+++ b/test/test_utils/dither_and_quantize.m
@@ -1,0 +1,61 @@
+%% xq = dither_and_quantize(x, bits)
+%
+% Input
+% x - input signal
+% bits - number of bits
+%
+% Output
+% (int32) xq - scaled, dithered and quantized signal
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+function xq = dither_and_quantize(x, bits)
+
+if (bits > 32) || (bits < 1)
+        error('This function supports max 32 bits quantization!');
+end
+
+scale = 2^(bits-1);
+smax = scale-1;
+smin = -scale;
+sx = size(x);
+nx = sx(1);
+nch = sx(2);
+
+xq = int32(floor( scale*x + randn(nx,nch) - randn(nx,nch) -0.5)); % TPDF dither
+%xq = int32(round( scale*x )); % Omit dither
+idx = find(xq > smax);
+xq(idx) = smax;
+idx = find(xq < smin);
+xq(idx) = smin;
+
+end

--- a/test/test_utils/find_test_signal.m
+++ b/test/test_utils/find_test_signal.m
@@ -1,0 +1,75 @@
+function [d, nt, nt_use, nt_skip] = find_test_signal(x, test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Find start marker
+fprintf('Finding test start marker...\n');
+s = sync_chirp(test.fs, 'up');
+nx = length(x);
+n_half = round(nx/2);
+n = min(round(test.fs*test.sm), n_half);
+y = x(1:n);
+[r, lags] = xcorr(y, s);
+[r_max, idx] = max(r);
+d_start = lags(idx);
+
+%% Find end marker
+fprintf('Finding test end marker...\n');
+s = sync_chirp(test.fs, 'down');
+n = min(round(test.fs*test.em),n_half);
+y = x(end-n+1:end);
+[r, lags] = xcorr(y, s);
+[r_max, idx] = max(r);
+d_end = nx-n+lags(idx);
+
+%% Check correct length of signal
+len = d_end-d_start;
+len_s = len/test.fs;
+ref_s = test.mark_t+test.nf*test.na*test.tl;
+if abs(len_s-ref_s) > test.mt
+        len_s
+        ref_s
+        error('Start and end markers were not found. Test play or capture quality may be poor');
+end
+
+%% Delay to first tone, length of tone in samples
+d = d_start + round(test.mark_t*test.fs);
+if (d < 0)
+	error('Invalid negative delay seen. Test play or capture quality may be poor');
+end
+nt = round(test.tl*test.fs);
+nt_use = nt -round(test.is*test.fs) -round(test.ie*test.fs);
+if nt_use < 0
+        error('Test signal length parameters must be wrong!');
+end
+nt_skip = round(test.is*test.fs);
+
+end

--- a/test/test_utils/load_test_output.m
+++ b/test/test_utils/load_test_output.m
@@ -1,0 +1,87 @@
+function [x, nx] = load_test_output(test)
+
+%% [x, n] = load_test_output(t)
+%
+% Input
+% t.fn_out     - file name to load
+% t.bits_out   - word length of data
+% t.fmt        - file format 'raw' or 'txt
+% t.ch         - channel to extract
+% t.nch        - number of channels in (interleaved) data
+%
+% Output
+% x - samples
+% n - number of samples
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Integer type for binary files
+switch test.bits_out
+	case 16
+		bfmt = 'int16';
+	case 24
+		bfmt = 'int32';
+	case 32
+		bfmt = 'int32';
+	otherwise
+		error('Bits_out must be 16, 24, or 32.');
+end
+
+%% Check that output file exists
+if exist(test.fn_out)
+        fprintf('Reading output data file %s...\n', test.fn_out);
+	switch lower(test.fmt)
+		case 'txt'
+			out = load(test.fn_out);
+		case 'raw'
+			fh = fopen(test.fn_out, 'r');
+			out = fread(fh, inf, bfmt);
+			fclose(fh);
+		otherwise
+			error('Fmt must be raw or txt.');
+	end
+else
+        out = [];
+end
+
+%% Exctract channels to measure
+scale = 1/2^(test.bits_out-1);
+lout = length(out);
+nx = floor(lout/test.nch);
+x = zeros(nx,length(test.ch));
+j = 1;
+for ch = test.ch
+        x(:,j) = out(ch:test.nch:end)*scale;
+        j = j + 1;
+end
+
+end

--- a/test/test_utils/mix_chirp.m
+++ b/test/test_utils/mix_chirp.m
@@ -1,0 +1,82 @@
+function  test = mix_chirp(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Adjust tone length to integer number of samples
+test.nt = round(test.cl*test.fs); % Make number of samples per tone
+test.tl = test.nt/test.fs;        % an integer by adjusting tl.
+
+%% Test start and end marker tones
+[h1, mark_start] = sync_chirp(test.fs, 'up');
+[h2, mark_end] = sync_chirp(test.fs, 'down');
+test.mark_t = mark_start.t;
+test.mark_a = mark_start.a;
+test.mark_a_db = mark_start.a_db;
+test.ts = mark_start.t;
+
+%% Idle time to start and end
+t_idle0 = 0.5;
+n_idle = round(test.fs*t_idle0);
+t_idle = n_idle/test.fs;
+x = zeros(test.nt + mark_start.n + mark_end.n +2*n_idle, test.nch, 'int32');
+
+%% Add markers
+idx1 = n_idle+1;
+idx2 = length(x)-n_idle-mark_end.n;
+for ch=test.ch
+        x(idx1:idx1+mark_start.n-1, ch) = dither_and_quantize(h1, test.bits_in);
+        x(idx2:idx2+mark_end.n-1, ch) = dither_and_quantize(h2, test.bits_in);
+end
+
+%% Dither also idle parts
+x(1:n_idle) = dither_and_quantize(zeros(n_idle,1), test.bits_in);
+x(end-n_idle+1:end) = dither_and_quantize(zeros(n_idle,1), test.bits_in);
+
+%% Add Chirp
+i1 = n_idle+mark_start.n+1;
+i2 = i1+test.nt-1;
+fprintf('Mixing %.1f dBFS chirp ...\n', test.a_db);
+tc = ((1:round(test.cl*test.fs))-1)/test.fs;
+s = test.a * chirp(tc, test.f_min, test.tl, test.f_max, 'linear');
+sign = 1;
+for ch=test.ch
+        x(i1:i2, ch) = dither_and_quantize(sign * s, test.bits_in);
+	sign = -sign;
+end
+
+test.signal = x;
+
+%% Output
+fprintf('Writing output data file %s...\n', test.fn_in);
+write_test_data(x, test.fn_in, test.bits_in, test.fmt);
+fprintf('Done.\n')
+
+end

--- a/test/test_utils/mix_sweep.m
+++ b/test/test_utils/mix_sweep.m
@@ -1,0 +1,103 @@
+function  test = mix_sweep(test)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Adjust tone lengt to integer number of samples
+test.nt = round(test.tl*test.fs); % Make number of samples per tone
+test.tl = test.nt/test.fs;        % an integer by adjusting tl.
+test.nf = length(test.f); % Number of frequencies
+test.na = length(test.a); % Number of amplitudes
+
+%% Test start and end marker tones
+[h1, mark_start] = sync_chirp(test.fs, 'up');
+[h2, mark_end] = sync_chirp(test.fs, 'down');
+test.mark_t = mark_start.t;
+test.mark_a = mark_start.a;
+test.mark_a_db = mark_start.a_db;
+test.ts = mark_start.t;
+
+%% Idle time to start and end
+t_idle0 = 0.5;
+n_idle = round(test.fs*t_idle0);
+t_idle = n_idle/test.fs;
+x = zeros(test.nf*test.na*test.nt +mark_start.n +mark_end.n +2*n_idle, ...
+        test.nch, 'int32');
+
+%% Add markers
+idx1 = n_idle+1;
+idx2 = length(x)-n_idle-mark_end.n;
+for ch=test.ch
+        x(idx1:idx1+mark_start.n-1, ch) = dither_and_quantize(h1, test.bits_in);
+        x(idx2:idx2+mark_end.n-1, ch) = dither_and_quantize(h2, test.bits_in);
+end
+
+%% Dither also idle parts
+x(1:n_idle) = dither_and_quantize(zeros(n_idle,1), test.bits_in);
+x(end-n_idle+1:end) = dither_and_quantize(zeros(n_idle,1), test.bits_in);
+
+%% Add discrete frequencies sweep
+n_r = round(test.fs*test.tr);
+win = ones(test.nt,1);
+win(1:n_r) = linspace(0,1,n_r);
+win(end-n_r+1:end) = linspace(1,0,n_r);
+i0 = n_idle+mark_start.n+1;
+nn = 1;
+for m=1:test.na
+        for n=1:test.nf
+                i1 = i0 + (nn-1)*test.nt+1;
+                i2 = i1+test.nt-1;
+                nn = nn+1;
+                if length(test.f) > 1
+                        f = test.f(n);
+                else
+                        f = test.f;
+                end
+                if length(test.a) > 1
+                        a = test.a(m);
+                else
+                        a = test.a;
+                end
+                fprintf('Mixing %.0f Hz %.1f dBFS sine ...\n', f, 20*log10(a));
+                s = multitone(test.fs, f, a, test.tl);
+                for ch=test.ch
+                        x(i1:i2, ch) = dither_and_quantize(s.*win, test.bits_in);
+                end
+        end
+end
+
+test.signal = x;
+
+%% Output
+fprintf('Writing output data file %s...\n', test.fn_in);
+write_test_data(x, test.fn_in, test.bits_in, test.fmt);
+fprintf('Done.\n')
+
+end

--- a/test/test_utils/mkdir_check.m
+++ b/test/test_utils/mkdir_check.m
@@ -1,0 +1,35 @@
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+function d = mkdir_check(d)
+if exist(d) ~= 7
+        mkdir(d);
+end
+end

--- a/test/test_utils/multitone.m
+++ b/test/test_utils/multitone.m
@@ -1,0 +1,61 @@
+function x = multitone( fs, f, amp, tlength )
+
+%%
+% Create single or multiple sine wave(s)
+%
+% x = multitone(fs, f, a, t);
+%
+% fs     - Sample rate
+% f      - Frequency (Hz)
+% a      - Amplitude (lin)
+% t      - Lenght in seconds
+%
+% Example:
+% x = multitone(48000, [997 1997], 10.^([-26 -46]/20), 1.0);
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+n = round(fs*tlength);
+t = (0:n-1)/fs;
+nf = length(f);
+if nf > 1
+        ph = rand(nf, 1)*2*pi;
+else
+        ph = 0;
+end
+
+x = amp(1)*sin(2*pi*f(1)*t');
+for i=2:length(f)
+        x = x + amp(i)*sin(2*pi*f(i)*t+ph(i));
+end
+
+end

--- a/test/test_utils/sync_chirp.m
+++ b/test/test_utils/sync_chirp.m
@@ -1,0 +1,68 @@
+function [y, mark]= sync_chirp(fs, direction)
+
+%% [y, mark]= sync_chirp(fs, direction)
+%
+% Returns a chirp signal that can be used to mark end and beginning of audio
+% tests to syncronize input and captured output accurately.
+%
+% Input
+% fs - sample rate
+% direction - direction of frequency sweep 'up' or 'down'
+%
+% Output
+% y - windowed chirp signal
+% mark - struct with parameters for chirp
+%
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+mark.a_db = -10;
+mark.a = 10^(mark.a_db/20);
+mark.fs = fs;
+mark.t = 0.2; % Short, to not consume much test time
+switch lower(direction)
+        case 'up'
+                mark.f0 = 200; % Should work with any speaker
+                mark.f1 = 3500; % Should work with any speaker
+        case 'down'
+                mark.f1 = 200; % Should work with any speaker
+                mark.f0 = 3500; % Should work with any speaker
+        otherwise
+                error('Parameter direction must be ''up'' or ''down''');
+end
+
+mark.n = round(mark.t*fs);
+t_vec = (0:mark.n-1)/fs;
+w = hanning(mark.n);
+x = chirp(t_vec, mark.f0, mark.t, mark.f1, 'linear')';
+y = x .* w * mark.a;
+
+end

--- a/test/test_utils/test_run.m
+++ b/test/test_utils/test_run.m
@@ -1,0 +1,53 @@
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+function test = test_run(test)
+
+if exist(test.ex) == 2
+	%fcmd = sprintf('file %s', test.ex);
+	%[status, output]=system(fcmd);
+	%if findstr(output, "Tensilica Xtensa")
+	%	ex = sprintf('xt-run --turbo --summary %s', test.ex);
+	%else
+		ex = test.ex;
+	%end
+else
+        error('Can''t find executable %s', test.ex);
+end
+test.narg = length(test.arg);
+arg = '';
+for n=1:test.narg
+        arg = sprintf('%s %s', arg, char(test.arg(n)));
+end
+rcmd = sprintf('%s %s', ex, arg);
+fprintf('Running ''%s''...\n', rcmd);
+system(rcmd);
+
+end

--- a/test/test_utils/write_test_data.m
+++ b/test/test_utils/write_test_data.m
@@ -1,0 +1,71 @@
+function write_test_data(x, fn, bits, fmt)
+
+%%
+% Copyright (c) 2017, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+switch lower(fmt)
+	case 'raw'
+		fh = fopen(fn, 'wb');
+	case 'txt'
+		fh = fopen(fn, 'w');
+	otherwise
+		error('The file format must be raw or txt');
+end
+switch bits
+	case 16
+		bfmt = 'int16';
+	case 24
+		bfmt = 'int32';
+	case 32
+		bfmt = 'int32';
+	otherwise
+		error('The bits must be set to 16, 24, or 32');
+end
+
+%% Interleave the channels if two or more
+sx = size(x);
+xi = zeros(sx(1)*sx(2), 1, bfmt);
+if sx(2) > 1
+        for n=1:sx(2)
+                xi(n:sx(2):end) = x(:,n);
+        end
+else
+	xi(1:end) = x;
+end
+
+%% Write file and close
+if strcmp(lower(fmt), 'raw')
+	fwrite(fh, xi, bfmt);
+else
+	fprintf(fh,'%d\n', xi);
+end
+fclose(fh);
+
+end


### PR DESCRIPTION
This is my patch set to add to SOFT test scripts for Sample Rate Conversion (SRC) component. The scripts are also the base for other audio processing component tests such as volume and equalizers.

Note: This depends on changes to host test bench in SOF to be able to load SRC library and parse the topology tokens. The features in the patch has been tested with an early draft version of the needed changes.

Note: The SRC tests have currently 1 fail of 247 tests with 64k -> 48k conversion that returns an overall fail from the top level test script. It's under study where the issue is (test bench or SRC component).