### PR TITLE
SOFT: Fix the topology file name in SRC test topology lookup

### DIFF
--- a/test/src_run.sh
+++ b/test/src_run.sh
@@ -18,7 +18,7 @@ HOST_LIB=$HOST_ROOT/lib
 INFMT=s${BITS_IN}le
 OUTFMT=s${BITS_IN}le
 MCLK=24576k
-TPLG=../topology/test/test-playback-ssp2-I2S-${COMP}-${INFMT}-${OUTFMT}-48k-${MCLK}-nocodec.tplg
+TPLG=../topology/test/test-playback-ssp2-mclk-0-I2S-${COMP}-${INFMT}-${OUTFMT}-48k-${MCLK}-nocodec.tplg
 
 # If binary test vectors
 if [ ${FN_IN: -4} == ".raw" ]; then


### PR DESCRIPTION
The topology files naming has been updated to include mclk-N so it
needs to be added here as well for the script src_run.sh to work.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>