### PR TITLE
SOFT: Increase SRC playback topology buffer size

### DIFF
--- a/topology/sof/pipe-src-playback.m4
+++ b/topology/sof/pipe-src-playback.m4
@@ -17,8 +17,8 @@ include(`pipeline.m4')
 #
 
 # Host "Passthrough Playback" PCM
-# with 4 sink and 0 source periods
-W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 4, 0, 2)
+# with 5 sink and 0 source periods
+W_PCM_PLAYBACK(PCM_ID, Passthrough Playback, 5, 0, 2)
 
 #
 # SRC Configuration
@@ -28,11 +28,11 @@ W_VENDORTUPLES(media_src_tokens, sof_src_tokens, LIST(`		', `SOF_TKN_SRC_RATE_OU
 
 W_DATA(media_src_conf, media_src_tokens)
 
-# "SRC" has 4 source and 4 sink periods
-W_SRC(0, PIPELINE_FORMAT, 4, 4, media_src_conf, 2)
+# "SRC" has 5 source and 4 sink periods
+W_SRC(0, PIPELINE_FORMAT, 5, 4, media_src_conf, 2)
 
 # Playback Buffers
-W_BUFFER(0, COMP_BUFFER_SIZE(4,
+W_BUFFER(0, COMP_BUFFER_SIZE(5,
 	COMP_SAMPLE_SIZE(PIPELINE_FORMAT), PIPELINE_CHANNELS, SCHEDULE_FRAMES),
 	PLATFORM_HOST_MEM_CAP)
 W_BUFFER(1, COMP_BUFFER_SIZE(4,


### PR DESCRIPTION
This patch increases the SRC source buffer to contain 5 periods of data
(measured for 1 ms @ 48 kHz ). It fixes the issue in 176.4 kHz to 48 kHz
playback conversion that the pipeline freezes with insufficient available
data in source buffer for SRC to convert and too little free in buffer
for host to fill another 48 frames.

176.4 kHz playback is currently the largest buffer size consumer due
to non-steady in/out rate. The higher rate conversion 192 kHz to 48 kHz
can operate with smaller size buffer due to steady in/out rate.

Note: This has been only simulated in the host test bench since SRC
playback does not run currently in real devices due to another issue.
However since buffers simulation is accurate this should be a real issue.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>