### PR TITLE
Revert "topology: dai: correct default_hw_conf_id"

### DIFF
--- a/topology/m4/dai.m4
+++ b/topology/m4/dai.m4
@@ -145,7 +145,7 @@ define(`DAI_CONFIG',
 `SectionBE."'$4`" {'
 `	id "'$3`"'
 `	index "0"'
-`	default_hw_conf_id	"0"'
+`	default_hw_conf_id	"'$2`"'
 `'
 `	hw_configs ['
 `		"'$1$2`"'


### PR DESCRIPTION
This reverts commit 229da95e0d5a9d8abce89a5bb3804926b74d1ba0 which call
regression:
https://github.com/thesofproject/soft/issues/15

Default_hw_conf_id is id, not index of array, revert to fix it.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>