### PR TITLE
SOFT: Improve audio test synchronization code

### DIFF
--- a/test/test_utils/chirp_test_analyze.m
+++ b/test/test_utils/chirp_test_analyze.m
@@ -38,7 +38,7 @@ if nx < 1
 end
 
 %% Find sync
-[d, nt, nt_use, nt_skip] = find_test_signal(x, test);
+[d, nt, nt_use, nt_skip] = find_test_signal(x(:,test.ch(1)), test);
 
 %% Trim sample
 i1 = d+nt_skip;

--- a/test/test_utils/chirp_test_input.m
+++ b/test/test_utils/chirp_test_input.m
@@ -77,7 +77,7 @@ test.fn_out =  sprintf('chirp_test_out.%s', test.fmt);
 test.a_db = -0.1; % Near full scale
 test.a = 10^(test.a_db/20);
 test.f_min = 20;
-test.f_max = test.fs/2;
+test.f_max = 0.99*test.fs/2;
 test.cl = 2.0;
 
 

--- a/test/test_utils/find_test_signal.m
+++ b/test/test_utils/find_test_signal.m
@@ -34,8 +34,8 @@ function [d, nt, nt_use, nt_skip] = find_test_signal(x, test)
 fprintf('Finding test start marker...\n');
 s = sync_chirp(test.fs, 'up');
 nx = length(x);
-n_half = round(nx/2);
-n = min(round(test.fs*test.sm), n_half);
+n_seek = round(test.fs*(test.idle_t + test.mark_t));
+n = min(round(test.fs*test.sm), n_seek);
 y = x(1:n);
 [r, lags] = xcorr(y, s);
 [r_max, idx] = max(r);
@@ -44,7 +44,8 @@ d_start = lags(idx);
 %% Find end marker
 fprintf('Finding test end marker...\n');
 s = sync_chirp(test.fs, 'down');
-n = min(round(test.fs*test.em),n_half);
+n_seek = round(test.fs*(2*test.idle_t + test.mark_t));
+n = min(round(test.fs*test.em),n_seek);
 y = x(end-n+1:end);
 [r, lags] = xcorr(y, s);
 [r_max, idx] = max(r);

--- a/test/test_utils/mix_chirp.m
+++ b/test/test_utils/mix_chirp.m
@@ -43,8 +43,8 @@ test.mark_a_db = mark_start.a_db;
 test.ts = mark_start.t;
 
 %% Idle time to start and end
-t_idle0 = 0.5;
-n_idle = round(test.fs*t_idle0);
+test.idle_t = 0.5;
+n_idle = round(test.fs*test.idle_t);
 t_idle = n_idle/test.fs;
 x = zeros(test.nt + mark_start.n + mark_end.n +2*n_idle, test.nch, 'int32');
 
@@ -65,7 +65,7 @@ i1 = n_idle+mark_start.n+1;
 i2 = i1+test.nt-1;
 fprintf('Mixing %.1f dBFS chirp ...\n', test.a_db);
 tc = ((1:round(test.cl*test.fs))-1)/test.fs;
-s = test.a * chirp(tc, test.f_min, test.tl, test.f_max, 'linear');
+s = test.a * chirp(tc, test.f_min, test.tl, test.f_max, 'linear', 90);
 sign = 1;
 for ch=test.ch
         x(i1:i2, ch) = dither_and_quantize(sign * s, test.bits_in);

--- a/test/test_utils/mix_sweep.m
+++ b/test/test_utils/mix_sweep.m
@@ -45,8 +45,8 @@ test.mark_a_db = mark_start.a_db;
 test.ts = mark_start.t;
 
 %% Idle time to start and end
-t_idle0 = 0.5;
-n_idle = round(test.fs*t_idle0);
+test.idle_t = 0.5;
+n_idle = round(test.fs*test.idle_t);
 t_idle = n_idle/test.fs;
 x = zeros(test.nf*test.na*test.nt +mark_start.n +mark_end.n +2*n_idle, ...
         test.nch, 'int32');


### PR DESCRIPTION
The audio tests signals contain a start and end marker to extract the
test output to analyze from in-between the markers.

This patch fixes a fail in SRC tests that was caused by incorrect
synchronization to output data. The chirp upper frequency is limited
to 0.99 x Nyquist frequency since the Nyquist frequency in the end
aliased and caused a visible artefact to spectral plot and it triggered
a resampler filter impulse response that had some correlation with
start/end marker chirps. The cosine chirp initialization to start from
90 degrees (zero PCM code instead of max.) also cleaned the start impulse
and improved the look of spectrogram plot.

The syncronization was limited to seek from one measured channel only. The
sync finder also didn't handle properly multi-channel input.

The output file start marker scan length was reduced to be
idle+marker length. And the scan time for end was reduced to be
2xidle+marker length

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>