### PR TITLE
SOFT: fix this topology failed to be loaded

### DIFF
--- a/topology/sof-byt-nocodec.m4
+++ b/topology/sof-byt-nocodec.m4
@@ -91,7 +91,7 @@ PCM_DUPLEX_ADD(Low Latency, 6, 0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 #
 # BE configurations - overrides config in ACPI if present
 #
-DAI_CONFIG(SSP, 2, 0, NoCodec-2,
+DAI_CONFIG(SSP, 2, 2, NoCodec-2,
 	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 2400000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),


### PR DESCRIPTION
Set dai id number according to NoCodec-id

Signed-off-by: Rander Wang <rander.wang@linux.intel.com>