### PR TITLE
topology: fix id for sof_cnl_rt274 topology

### DIFF
--- a/topology/sof-cnl-rt274.m4
+++ b/topology/sof-cnl-rt274.m4
@@ -63,7 +63,7 @@ PCM_DUPLEX_ADD(Passthrough, 3, 0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 #
 # BE configurations - overrides config in ACPI if present
 #
-DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
+DAI_CONFIG(SSP, 0, 1, SSP0-Codec,
 	   SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, 24000000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 4800000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),


### PR DESCRIPTION
Codec SSP id doesn't match with machine driver, so
change the id to 1 to fix the topology loading issue.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>