### PR TITLE
Tone updates

### DIFF
--- a/topology/m4/dai.m4
+++ b/topology/m4/dai.m4
@@ -188,4 +188,14 @@ define(`DAI_ADD',
 `include($1)'
 )
 
+dnl VFE_LINK(link_name, cpu_dai_name, platform_name)
+define(`VFE_LINK',
+`	tokens "sof_vfe_tokens"'
+`	tuples."string" {'
+`		SOF_TKN_VFE_LINK_NAME'		STR($1)
+`		SOF_TKN_VFE_CPU_DAI_NAME'	$2
+`		SOF_TKN_VFE_PLATFORM_NAME'	STR($3)
+`	}'
+)
+
 divert(0)dnl

--- a/topology/m4/tone.m4
+++ b/topology/m4/tone.m4
@@ -18,11 +18,13 @@ define(`W_TONE',
 `SectionVendorTuples."'N_TONE($1)`_tone_tuples_w" {'
 `	tokens "sof_tone_tokens"'
 `	tuples."word" {'
-`		SOF_TKN_TONE_SAMPLE_RATE'		ifdef(TONE_SAMPLE_RATE, STR(TONE_SAMPLE_RATE), "48000")
+`		SOF_TKN_TONE_SAMPLE_RATE'		ifdef(`TONE_SAMPLE_RATE', STR(TONE_SAMPLE_RATE), "48000")
 `	}'
 `}'
 `SectionData."'N_TONE($1)`_data_w" {'
 `	tuples "'N_TONE($1)`_tuples_w"'
+`}'
+`SectionData."'N_TONE($1)`_tone_data_w" {'
 `	tuples "'N_TONE($1)`_tone_tuples_w"'
 `}'
 `SectionVendorTuples."'N_TONE($1)`_tuples_str" {'
@@ -31,8 +33,14 @@ define(`W_TONE',
 `		SOF_TKN_COMP_FORMAT'	STR($2)
 `	}'
 `}'
+`SectionVendorTuples."'N_TONE($1)`_vfe_tuples_str" {'
+VFE_LINK(VFE_LINK_NAME, STR(`TEST_VFE_CPU_DAI_NAME'), VFE_PLATFORM_NAME)
+`}'
 `SectionData."'N_TONE($1)`_data_str" {'
 `	tuples "'N_TONE($1)`_tuples_str"'
+`}'
+`SectionData."'N_TONE($1)`_vfe_data_str" {'
+`	tuples "'N_TONE($1)`_vfe_tuples_str"'
 `}'
 `SectionWidget."'N_TONE($1)`" {'
 `	index "'PIPELINE_ID`"'
@@ -40,7 +48,9 @@ define(`W_TONE',
 `	no_pm "true"'
 `	data ['
 `		"'N_TONE($1)`_data_w"'
+`		"'N_TONE($1)`_tone_data_w"'
 `		"'N_TONE($1)`_data_str"'
+`		"'N_TONE($1)`_vfe_data_str"'
 `	]'
 `	mixer ['
 		$6

--- a/topology/sof/tokens.m4
+++ b/topology/sof/tokens.m4
@@ -82,3 +82,9 @@ SectionVendorTokens."sof_dmic_pdm_tokens" {
 SectionVendorTokens."sof_tone_tokens" {
 	SOF_TKN_TONE_SAMPLE_RATE		"800"
 }
+
+SectionVendorTokens."sof_vfe_tokens" {
+	SOF_TKN_VFE_LINK_NAME			"900"
+	SOF_TKN_VFE_CPU_DAI_NAME		"901"
+	SOF_TKN_VFE_PLATFORM_NAME		"902"
+}

--- a/topology/test/test-tone-playback.m4
+++ b/topology/test/test-tone-playback.m4
@@ -40,6 +40,10 @@ include(`byt.m4')
 # Set sample rate for tone
 define(`TONE_SAMPLE_RATE', 48000)
 
+# Define virtual FE DAI link for tone
+define(`VFE_LINK_NAME', TONE_VFE0)
+define(`VFE_PLATFORM_NAME', sof-audio)
+
 # Tone Playback pipeline 5 using max 2 channels of TEST_PIPE_FORMAT.
 # Schedule with 48 frame per 1000us deadline on core 0 with priority 0
 PIPELINE_ADD(sof/pipe-tone.m4,

--- a/topology/test/tplg-build.sh
+++ b/topology/test/tplg-build.sh
@@ -122,6 +122,33 @@ function simple_test {
 	done
 }
 
+function tone_test {
+	echo ${14}
+	TESTS=("${!15}")
+	for i in ${TESTS[@]}
+	do
+		TFILE="$i-ssp$6-mclk-${13}-${12}-$2-$4-$7-48k-$((${11} / 1000))k-$1"
+		echo "M4 pre-processing test $i -> ${TFILE}"
+		m4 ${M4_FLAGS} \
+			-DTEST_PIPE_NAME="$2" \
+			-DTEST_DAI_LINK_NAME="$3" \
+			-DTEST_DAI_PORT=$6 \
+			-DTEST_DAI_FORMAT=$7 \
+			-DTEST_PIPE_FORMAT=$4 \
+			-DTEST_SSP_BCLK=${10} \
+			-DTEST_SSP_MCLK=${11} \
+			-DTEST_SSP_PHY_BITS=$8 \
+			-DTEST_SSP_DATA_BITS=$9 \
+			-DTEST_SSP_MODE=${12} \
+			-DTEST_SSP_MCLK_ID=${13} \
+			-DTEST_VFE_CPU_DAI_NAME="${14}" \
+			-DTEST_DAI_TYPE=$5 \
+			$i.m4 > ${TFILE}.conf
+		echo "Compiling test $i -> ${TFILE}.tplg"
+		alsatplg -v 1 -c ${TFILE}.conf -o ${TFILE}.tplg
+	done
+}
+
 echo "Preparing topology build input..."
 
 # Pre-process the simple tests
@@ -213,10 +240,10 @@ simple_test nocodec volume "NoCodec-2" s24le SSP 2 s16le 25 16 2400000 24000000 
 simple_test nocodec src "NoCodec-4" s24le SSP 4 s24le 25 24 2400000 24000000 I2S 0 SIMPLE_TESTS[@]
 
 # Tone test: Tone component only supports s32le currently
-simple_test codec tone "SSP2-Codec" s32le SSP 2 s16le 20 16 1920000 19200000 I2S 0 TONE_TEST[@]
+tone_test codec tone "SSP2-Codec" s32le SSP 2 s16le 20 16 1920000 19200000 I2S 0 "ssp2-port" TONE_TEST[@]
 #Tone Test for APL
-simple_test codec tone "SSP5-Codec" s32le SSP 5 s24le 32 24 3072000 24576000 I2S 0 TONE_TEST[@]
-simple_test codec tone "SSP5-Codec" s32le SSP 5 s32le 32 32 3072000 24576000 I2S 0 TONE_TEST[@]
+tone_test codec tone "SSP5-Codec" s32le SSP 5 s24le 32 24 3072000 24576000 I2S 0 "SSP5 Pin" TONE_TEST[@]
+tone_test codec tone "SSP5-Codec" s32le SSP 5 s32le 32 32 3072000 24576000 I2S 0 "SSP5 Pin" TONE_TEST[@]
 
 # DMIC Test Topologies for APL/GLK
 DMIC_PDM_CONFIGS=(MONO_PDM0_MICA MONO_PDM0_MICB STEREO_PDM0 STEREO_PDM1 FOUR_CH_PDM0_PDM1)


### PR DESCRIPTION
This set of patches adds the changes required to add the virtual FE DAI link information in the
tone pipeline topology. 