### PR TITLE
topology: sof-apl-tdf8532: change SSP2 to 2 channels.

### DIFF
--- a/topology/sof-apl-tdf8532.m4
+++ b/topology/sof-apl-tdf8532.m4
@@ -41,13 +41,13 @@ PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
 # Low Latency playback pipeline 2 on PCM 1 using max 8 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	2, 1, 8, s32le,
+	2, 1, 2, s32le,
 	48, 1000, 0, 0, SSP, 2, s32le, 2)
 
 # Low Latency capture pipeline 3 on PCM 1 using max 8 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	3, 1, 8, s32le,
+	3, 1, 2, s32le,
 	48, 1000, 0, 0, SSP, 2, s32le, 2)
 
 # Low Latency playback pipeline 4 on PCM 2 using max 2 channels of s16le.
@@ -192,11 +192,17 @@ DAI_CONFIG(SSP, 1, 1, SSP1-Codec,
 		      SSP_TDM(2, 16, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 1, 16)))
 
+# For SSP2, we are using TDM-8 mode with Dirana
+# slot 0/1: FM L/R;
+# slot 2/3: Aux IN L/R;
+# slot 4/5: Mic
+# Currently, only Mic capture is enabled, so let's set mask to enable Mic only, that is 48.
+# Please set it to 256 once we can split stream from a SSP in Firmware and all those input are actually enabled and we want them.
 DAI_CONFIG(SSP, 2, 2, SSP2-Codec,
 	   SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		      SSP_CLOCK(bclk, 12288000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
-		      SSP_TDM(8, 32, 255, 255),
+		      SSP_TDM(8, 32, 48, 48),
 		      SSP_CONFIG_DATA(SSP, 2, 32)))
 
 DAI_CONFIG(SSP, 3, 3, SSP3-Codec,


### PR DESCRIPTION
Change SSP2 to use slot 4/5 of TDM-8 for stereo capture with Dirana.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>

it's verified on gpmrb.

hi @zhigang-wu please help review.