### PR TITLE
topology: fix sof-apl-pcm512x

### DIFF
--- a/topology/sof-apl-pcm512x.m4
+++ b/topology/sof-apl-pcm512x.m4
@@ -16,62 +16,32 @@ include(`sof/tokens.m4')
 
 # Include Apollolake DSP configuration
 include(`platform/intel/bxt.m4')
-include(`platform/intel/dmic.m4')
 
 #
 # Define the pipelines
 #
 # PCM0 ----> volume -----> SSP5 (pcm512x)
-#      <---- volume <----- SSP5
-# PCM1 <---- volume <----- DMIC0 (SSP3)
 #
 
-# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s16le.
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s16le,
-	48, 1000, 0, 0, SSP, 5, s16le, 2)
-
-# Low Latency capture pipeline 3 on PCM 1 using max 2 channels of s16le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	2, 0, 2, s16le,
-	48, 1000, 0, 0, SSP, 5, s16le, 2)
-
-# Low Latency capture pipeline 1 on PCM 0 using max 4 channels of s32le.
-# Schedule 48 frames per 1000us deadline on core 0 with priority 0
-PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-	3, 1, 4, s32le,
-	48, 1000, 0, 0, DMIC, 0, s32le, 2)
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	48, 1000, 0, 0)
 
 #
 # DAIs configuration
 #
 
 # playback DAI is SSP5 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, SSP, 5, SSP5-Codec,
-	PIPELINE_SOURCE_1, 2, s16le,
-	48, 1000, 0, 0)
-
-# capture DAI is SSP5 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	2, SSP, 5, SSP5-Codec,
-	PIPELINE_SINK_2, 2, s16le,
-	48, 1000, 0, 0)
-
-# capture DAI is DMIC0 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-DAI_ADD(sof/pipe-dai-capture.m4,
-	3, DMIC, 0, DMIC0,
-	PIPELINE_SINK_3, 2, s32le,
+	PIPELINE_SOURCE_1, 2, s24le,
 	48, 1000, 0, 0)
 
 # PCM Low Latency, id 0
-PCM_DUPLEX_ADD(Port5, 0, 0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
-PCM_CAPTURE_ADD(Dmic0, 1, 1, 1, PIPELINE_PCM_3)
+PCM_PLAYBACK_ADD(Port5, 0, 0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 
 #
 # BE configurations - overrides config in ACPI if present
@@ -79,12 +49,7 @@ PCM_CAPTURE_ADD(Dmic0, 1, 1, 1, PIPELINE_PCM_3)
 
 DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
-		SSP_CLOCK(bclk, 1536000, codec_slave),
+		SSP_CLOCK(bclk, 3072000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
-		SSP_TDM(2, 16, 3, 3),
-		SSP_CONFIG_DATA(SSP, 5, 16)))
-
-DAI_CONFIG(DMIC, 0, 1, DMIC0,
-	DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
-		DMIC_WORD_LENGTH(s32le), DMIC, 0,
-		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
+		SSP_TDM(2, 32, 3, 3),
+		SSP_CONFIG_DATA(SSP, 5, 24)))


### PR DESCRIPTION
Remove DMIC support to avoid topology load fail,
Remove capture (not supported by PCM512x codec)
Simplify structure using PCM_PIPELINE_ADD instead of PCM_PIPELINE_DAI_ADD
Enable 24-bit output
Enable up to 32-bit PCM (tested with S16_LE and S32_LE)

Tested on Up2, no issues detected.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>