### PR TITLE
topology: sof-apl-nocodec: enable all 6 SSPs

### DIFF
--- a/topology/sof-apl-nocodec.m4
+++ b/topology/sof-apl-nocodec.m4
@@ -22,7 +22,7 @@ include(`platform/intel/bxt.m4')
 #
 # PCM0 ----> volume -----> SSP0
 #      <---- volume <----- SSP0
-# PCM1 <---- Volume <----- SSP1
+# PCM1 ----> Volume <----- SSP1
 #      <---- Volume <----- SSP1
 # PCM2 ----> volume -----> SSP2
 #      <---- Volume <----- SSP2
@@ -84,27 +84,27 @@ PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
 
 # Low Latency playback pipeline 9 on PCM 4 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-#	9, 4, 2, s16le,
-#	48, 1000, 0, 0, SSP, 4, s16le, 2)
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+	9, 4, 2, s16le,
+	48, 1000, 0, 0, SSP, 4, s16le, 2)
 
 # Low Latency capture pipeline 10 on PCM 4 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-#	10, 4, 2, s16le,
-#	48, 1000, 0, 0, SSP, 4, s16le, 2)
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+	10, 4, 2, s16le,
+	48, 1000, 0, 0, SSP, 4, s16le, 2)
 
 # Low Latency playback pipeline 11 on PCM 5 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
-#	11, 5, 2, s16le,
-#	48, 1000, 0, 0, SSP, 5, s16le, 2)
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-playback.m4,
+	11, 5, 2, s16le,
+	48, 1000, 0, 0, SSP, 5, s16le, 2)
 
 # Low Latency capture pipeline 12 on PCM 5 using max 2 channels of s16le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
-#PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
-#	12, 5, 2, s16le,
-#	48, 1000, 0, 0, SSP, 5, s16le, 2)
+PIPELINE_PCM_DAI_ADD(sof/pipe-volume-capture.m4,
+	12, 5, 2, s16le,
+	48, 1000, 0, 0, SSP, 5, s16le, 2)
 
 
 #
@@ -169,39 +169,39 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 
 # playback DAI is SSP4 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-#DAI_ADD(sof/pipe-dai-playback.m4,
-#	9, SSP, 4, NoCodec,
-#	PIPELINE_SOURCE_9, 2, s16le,
-#	48, 1000, 0, 0)
+DAI_ADD(sof/pipe-dai-playback.m4,
+	9, SSP, 4, NoCodec-4,
+	PIPELINE_SOURCE_9, 2, s16le,
+	48, 1000, 0, 0)
 
 # capture DAI is SSP4 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-#DAI_ADD(sof/pipe-dai-capture.m4,
-#	10, SSP, 4, NoCodec,
-#	PIPELINE_SINK_10, 2, s16le,
-#	48, 1000, 0, 0)
+DAI_ADD(sof/pipe-dai-capture.m4,
+	10, SSP, 4, NoCodec-4,
+	PIPELINE_SINK_10, 2, s16le,
+	48, 1000, 0, 0)
 
 # playback DAI is SSP5 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-#DAI_ADD(sof/pipe-dai-playback.m4,
-#	11, SSP, 5, NoCodec,
-#	PIPELINE_SOURCE_11, 2, s16le,
-#	48, 1000, 0, 0)
+DAI_ADD(sof/pipe-dai-playback.m4,
+	11, SSP, 5, NoCodec-5,
+	PIPELINE_SOURCE_11, 2, s16le,
+	48, 1000, 0, 0)
 
 # capture DAI is SSP5 using 2 periods
 # Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
-#DAI_ADD(sof/pipe-dai-capture.m4,
-#	12, SSP, 5, NoCdec,
-#	PIPELINE_SINK_12, 2, s16le,
-#	48, 1000, 0, 0)
+DAI_ADD(sof/pipe-dai-capture.m4,
+	12, SSP, 5, NoCodec-5,
+	PIPELINE_SINK_12, 2, s16le,
+	48, 1000, 0, 0)
 
 # PCM Low Latency, id 0
 PCM_DUPLEX_ADD(Port0, 0, 0, 0, PIPELINE_PCM_1, PIPELINE_PCM_2)
 PCM_DUPLEX_ADD(Port1, 1, 1, 1, PIPELINE_PCM_3, PIPELINE_PCM_4)
 PCM_DUPLEX_ADD(Port2, 2, 2, 2, PIPELINE_PCM_5, PIPELINE_PCM_6)
 PCM_DUPLEX_ADD(Port3, 3, 3, 3, PIPELINE_PCM_7, PIPELINE_PCM_8)
-#PCM_DUPLEX_ADD(Port4, 4, 4, 4, PIPELINE_PCM_9, PIPELINE_PCM_10)
-#PCM_DUPLEX_ADD(Port5, 5, 5, 5, PIPELINE_PCM_11, PIPELINE_PCM_12)
+PCM_DUPLEX_ADD(Port4, 4, 4, 4, PIPELINE_PCM_9, PIPELINE_PCM_10)
+PCM_DUPLEX_ADD(Port5, 5, 5, 5, PIPELINE_PCM_11, PIPELINE_PCM_12)
 
 #
 # BE configurations - overrides config in ACPI if present
@@ -235,17 +235,17 @@ DAI_CONFIG(SSP, 3, 3, NoCodec-3,
 		      SSP_TDM(2, 16, 3, 3),
 		      SSP_CONFIG_DATA(SSP, 3, 16)))
 
-#DAI_CONFIG(SSP, 4, 0, NoCodec,
-#	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
-#		      SSP_CLOCK(bclk, 1536000, codec_slave),
-#		      SSP_CLOCK(fsync, 48000, codec_slave),
-#		      SSP_TDM(2, 16, 3, 3),
-#		      SSP_CONFIG_DATA(SSP, 4, 16)))
+DAI_CONFIG(SSP, 4, 4, NoCodec-4,
+	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 1536000, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, 16, 3, 3),
+		      SSP_CONFIG_DATA(SSP, 4, 16)))
 
-#DAI_CONFIG(SSP, 5, 0, NoCodec,
-#	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
-#		      SSP_CLOCK(bclk, 1536000, codec_slave),
-#		      SSP_CLOCK(fsync, 48000, codec_slave),
-#		      SSP_TDM(2, 16, 3, 3),
-#		      SSP_CONFIG_DATA(SSP, 5, 16)))
+DAI_CONFIG(SSP, 5, 5, NoCodec-5,
+	   SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 1536000, codec_slave),
+		      SSP_CLOCK(fsync, 48000, codec_slave),
+		      SSP_TDM(2, 16, 3, 3),
+		      SSP_CONFIG_DATA(SSP, 5, 16)))
 


### PR DESCRIPTION
For some reason parts of the topology were commented out.  Make sure
all 6 SSPs are enabled.

Tested on Up2 with a LogicPro-based check on SSP5 (only interface
accessive on the HAT connector)

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>