### PR TITLE
topology: fix Makefile.am

### DIFF
--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -65,4 +65,4 @@ EXTRA_DIST = \
 	sof-apl-tdf8532.m4 \
 	sof-apl-pcm512x.m4 \
 	sof-glk-codec.m4 \
-	sof-icl-nocodec.tplg
+	sof-icl-nocodec.m4


### PR DESCRIPTION
copy/paste mistake

Fixes: 3dd17dc0 ('dist: fix make dist for topology M4')
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>