### PR TITLE
topology: fix BE DAI id to be set to ID (not index)

### DIFF
--- a/topology/m4/dai.m4
+++ b/topology/m4/dai.m4
@@ -128,7 +128,7 @@ dnl DAI_CONFIG(type, idx, link_id, name, ssp_config/dmic_config)
 define(`DAI_CONFIG',
 `SectionHWConfig."'$1$2`" {'
 `'
-`	id		"'$2`"'
+`	id		"'$3`"'
 `'
 `	ifelse($1, `SSP', $5, `}')'
 `ifelse($1, `DMIC', $5, `')'
@@ -145,7 +145,7 @@ define(`DAI_CONFIG',
 `SectionBE."'$4`" {'
 `	id "'$3`"'
 `	index "0"'
-`	default_hw_conf_id	"'$2`"'
+`	default_hw_conf_id	"'$3`"'
 `'
 `	hw_configs ['
 `		"'$1$2`"'


### PR DESCRIPTION
Previously it was set to be the dai index which works if there's
only one type of BE DAI's.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>