### PR TITLE
tplg:token:add tokens for ssp register config

### DIFF
--- a/topology/platform/common/ssp.m4
+++ b/topology/platform/common/ssp.m4
@@ -26,8 +26,8 @@ define(`SSP_CONFIG',
 $6
 )
 
-dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id)
-dnl mclk_id is optional
+dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id, quirks, frame_pulse_width)
+dnl mclk_id quirks frame_pulse_width are optional
 define(`SSP_CONFIG_DATA',
 `SectionVendorTuples."'N_DAI_CONFIG($1$2)`_tuples" {'
 `	tokens "sof_ssp_tokens"'
@@ -36,6 +36,12 @@ define(`SSP_CONFIG_DATA',
 `	}'
 `	tuples."short" {'
 `		SOF_TKN_INTEL_SSP_MCLK_ID'	ifelse($4, `', "0", STR($4))
+`	}'
+`	tuples."word" {'
+`		SOF_TKN_INTEL_SSP_QUIRKS'	ifelse($5, `', "0", STR($5))
+`	}'
+`	tuples."short" {'
+`		SOF_TKN_INTEL_SSP_FRAME_PULSE_WIDTH'	ifelse($6, `', "0", STR($6))
 `	}'
 `}'
 `SectionData."'N_DAI_CONFIG($1$2)`_data" {'

--- a/topology/sof-apl-nocodec.m4
+++ b/topology/sof-apl-nocodec.m4
@@ -239,7 +239,7 @@ DAI_CONFIG(SSP, 0, 0, NoCodec-0,
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
-		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id)
+		      dnl SSP_CONFIG_DATA(type, dai_index, valid bits, mclk_id, quirks, frame_pulse_width)
 		      SSP_CONFIG_DATA(SSP, 0, 16)))
 
 DAI_CONFIG(SSP, 1, 1, NoCodec-1,

--- a/topology/sof-apl-tdf8532.m4
+++ b/topology/sof-apl-tdf8532.m4
@@ -183,6 +183,7 @@ DAI_CONFIG(SSP, 0, 0, SSP0-Codec,
 		      SSP_CLOCK(bclk, 1536000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
 		      SSP_TDM(2, 16, 3, 3),
+		      dnl SSP_CONFIG_DATA(type, idx, valid bits, mclk_id, quirks, frame_pulse_width)
 		      SSP_CONFIG_DATA(SSP, 0, 16)))
 
 DAI_CONFIG(SSP, 1, 1, SSP1-Codec,

--- a/topology/sof/tokens.m4
+++ b/topology/sof/tokens.m4
@@ -56,6 +56,8 @@ SectionVendorTokens."sof_ssp_tokens" {
 	SOF_TKN_INTEL_SSP_FS_KEEP_ACTIVE	"502"
 	SOF_TKN_INTEL_SSP_MCLK_ID		"503"
 	SOF_TKN_INTEL_SSP_SAMPLE_BITS		"504"
+	SOF_TKN_INTEL_SSP_FRAME_PULSE_WIDTH	"505"
+	SOF_TKN_INTEL_SSP_QUIRKS			"506"
 }
 
 SectionVendorTokens."sof_dmic_tokens" {


### PR DESCRIPTION
add more tokens for ssp register config.

the kernel and firmware should be changed to support
this feature.

Signed-off-by: Wu Zhigang <zhigang.wu@linux.intel.com>