### PR TITLE
SOFT: Add equalizer tuning scripts and small examples

### DIFF
--- a/tune/eq/eq_align.m
+++ b/tune/eq/eq_align.m
@@ -1,0 +1,52 @@
+function  [am, offs, p] = eq_align(f, m, f_align, m_align)
+
+%% [am, offs, p] = eq_align(f, m, f_align, m_align)
+%
+% Move by adding/subtracting an offset to frequency response
+% curve to cross desired frequency and magnitude, usually 997 Hz, 0 dB
+%
+% Input
+% f - frequencies
+% m - magnitude response
+%
+% Output
+% am - aligned magnitude resposne
+% offs - offset (gain) in decibels used
+% p - index of f_align in f
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+p = find(f < f_align, 1, 'last')+1;
+offs = m_align-m(p);
+am = m+offs;
+
+end

--- a/tune/eq/eq_alsactl_write.m
+++ b/tune/eq/eq_alsactl_write.m
@@ -1,0 +1,56 @@
+function eq_alsactl_write(fn, blob8)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Write blob
+fh = fopen(fn, 'w');
+
+%% Pad blob length to multiple of four bytes
+n_orig = length(blob8);
+n_new = ceil(n_orig/4);
+blob8_new = zeros(1, n_new*4);
+blob8_new(1:n_orig) = blob8;
+
+%% Convert to 32 bit
+blob32 = zeros(1, n_new, 'uint32');
+k = 2.^[0 8 16 24];
+for i=1:n_new
+	j = (i-1)*4;
+	blob32(i) = blob8_new(j+1)*k(1) + blob8_new(j+2)*k(2) ...
+		    +  blob8_new(j+3)*k(3) + blob8_new(j+4)*k(4);
+end
+for i=1:n_new-1
+	fprintf(fh, '%ld,', blob32(i));
+end
+fprintf(fh, '%ld,\n', blob32(end));
+fclose(fh);
+
+end

--- a/tune/eq/eq_blob_write.m
+++ b/tune/eq/eq_blob_write.m
@@ -1,0 +1,49 @@
+function eq_blob_write(fn, blob8)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Write blob
+fh = fopen(fn, 'wb');
+fwrite(fh, blob8, 'uint8');
+fclose(fh);
+
+%% Print as 8 bit hex
+nb = length(blob8);
+nl = ceil(nb/16);
+for i = 1:nl
+	m = min(16, nb-(i-1)*16);
+	for j = 1:m
+		fprintf(1, "%02x ", blob8((i-1)*16 + j));
+	end
+	fprintf(1, "\n");
+end
+
+end

--- a/tune/eq/eq_coef_quant.m
+++ b/tune/eq/eq_coef_quant.m
@@ -1,0 +1,50 @@
+function qc = eq_coef_quant(c, bits, qf)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+scale = 2^qf;
+cmax =  2^(bits-1)-1;
+cmin = -2^(bits-1);
+qc = int64(round(c*scale));
+idx = find(qc > cmax);
+if ~isempty(idx)
+        fprintf('Warning: Max. value of Q format is exceeded: %d (%d)\n', ...
+                qc(idx(1)), cmax);
+        qc(idx) = cmax;
+end
+idx = find(qc < cmin);
+if ~isempty(idx)
+        fprintf('Warning: Min. value of Q format is exceeded: %d (%d)\n', ...
+                qc(idx(1)), cmin);
+        qc(idx) = cmin;
+end
+
+end

--- a/tune/eq/eq_compute.m
+++ b/tune/eq/eq_compute.m
@@ -1,0 +1,458 @@
+function eq = eq_compute( eq )
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Extrapolate response to 0..fs/2, convert to logaritmic grid, and smooth
+%  with 1/N octave filter
+eq = preprocess_responses(eq);
+
+%% Define target (e.g. speaker) response as parametric filter. This could also
+%  be numerical data interpolated to the grid.
+if length(eq.parametric_target_response) > 0
+        [eq.b_t, eq.a_t] = eq_define_parametric_eq( ...
+                eq.parametric_target_response, eq.fs);
+        eq.t_db = eq_compute_response(eq.b_t, eq.a_t, eq.f, eq.fs);
+end
+
+if isempty(eq.t_db)
+        fprintf('Warning: No target response is defined.\n');
+end
+
+%% Align responses at some frequency and dB
+[eq.m_db_s, offs] = eq_align(eq.f, eq.m_db_s, eq.f_align, eq.db_align);
+eq.raw_m_db = eq.raw_m_db + offs;
+eq.m_db = eq.m_db + offs;
+eq.t_db = eq_align(eq.f, eq.t_db, eq.f_align, eq.db_align);
+
+%% Error to equalize = target - raw response, apply 1/N octave smoothing to
+%  soften the EQ shape
+eq.err_db = eq.t_db - eq.m_db;
+[eq.err_db_s, eq.logsmooth_noct] = logsmooth(eq.f, eq.err_db, eq.logsmooth_eq);
+
+%% Parametric IIR EQ definition
+if eq.enable_iir
+        [eq.b_p, eq.a_p] = eq_define_parametric_eq(eq.peq, eq.fs);
+        if length(eq.b_p) > 2*eq.iir_biquads_max+1
+                error('Maximum number of IIR biquads is exceeded');
+        end
+else
+        eq.b_p = 1;
+        eq.a_p = 1;
+end
+[eq.iir_eq_db, eq.iir_eq_ph, eq.iir_eq_gd] = eq_compute_response(eq.b_p, ...
+        eq.a_p, eq.f, eq.fs);
+
+
+%% FIR EQ computation
+%  Find remaining responses error ater IIR for FIR to handle
+if eq.fir_compensate_iir
+        eq.err2_db = eq.err_db_s-eq.iir_eq_db;
+else
+        eq.err2_db = eq.err_db_s;
+end
+
+if eq.enable_fir
+        [eq.t_fir_db, eq.fmin_fir, eq.fmax_fir] = ...
+                get_fir_target(eq.f, eq.err2_db, eq.fmin_fir, eq.fmax_fir, ...
+                eq.amin_fir, eq.amax_fir, eq.logsmooth_noct, eq.fir_autoband);
+
+        if eq.fir_minph
+                eq.b_fir = compute_minph_fir(eq.f, eq.t_fir_db, ...
+                        eq.fir_length, eq.fs, eq.fir_beta);
+        else
+                eq.b_fir = compute_linph_fir(eq.f, eq.t_fir_db, ...
+                        eq.fir_length, eq.fs, eq.fir_beta);
+        end
+else
+        eq.b_fir = 1;
+        eq.tfirdb = zeros(1,length(eq.f));
+end
+
+%% Update all responses
+eq = eq_compute_tot_response(eq);
+
+%% Normalize
+eq = eq_norm(eq);
+
+end
+
+function eq = preprocess_responses(eq)
+%% Usually too narrow measurement without the lowest and highest frequencies
+[f0, m0, gd0] = fix_response_dcnyquist_mult(eq.raw_f, eq.raw_m_db, ...
+        eq.raw_gd_s, eq.fs);
+
+%% Create dense logarithmic frequency grid, then average possible multiple
+%  measurements
+[eq.f, eq.m_db, eq.gd_s, eq.num_responses] = map_to_logfreq_mult(f0, m0, ...
+        gd0, 1, eq.fs/2, eq.np_fine);
+
+%% Smooth response with 1/N octave filter for plotting
+eq.m_db_s = logsmooth(eq.f, eq.m_db, eq.logsmooth_plot);
+
+if length(eq.target_m_db) > 0
+        % Use target_m_db as dummy group delay, ignore other than magnitude
+        [f0, m0, ~] = fix_response_dcnyquist_mult(eq.target_f, ...
+                eq.target_m_db, [], eq.fs);
+        [~, eq.t_db, ~, ~] = map_to_logfreq_mult(f0, m0, [], 1, ...
+                eq.fs/2, eq.np_fine);
+end
+end
+
+
+function [f_hz, m_db, gd_s] = fix_response_dcnyquist(f_hz0, m_db0, gd_s0, fs)
+%% Append DC and Fs/2 if missing
+f_hz = f_hz0;
+m_db = m_db0;
+gd_s = gd_s0;
+if min(f_hz) >  0
+        f_hz = [0 f_hz];
+        m_db = [m_db(1) m_db]; % DC the same as 1st measured point
+        if length(gd_s) > 0
+                gd_s = [gd_s(1) gd_s]; % DC the same as 1st measured point
+        end
+end
+if max(f_hz) <  fs/2
+        f_hz = [f_hz fs/2];
+        m_db = [m_db m_db(end)]; % Fs/2 the same as last measured point
+        if length(gd_s) > 0
+                gd_s = [gd_s gd_s(end)]; % Fs/2 the same as last measured point
+        end
+end
+end
+
+function [f_hz, m_db, gd_s] = fix_response_dcnyquist_mult(f_hz0, m_db0, ...
+        gd_s0, fs)
+
+if iscolumn(f_hz0)
+        f_hz0 = f_hz0.';
+end
+if iscolumn(m_db0)
+        m_db0 = m_db0.';
+end
+if iscolumn(gd_s0)
+        gd_s0 = gd_s0.';
+end
+
+s1 = size(f_hz0);
+s2 = size(m_db0);
+s3 = size(gd_s0);
+
+if s1(1) == 0
+        error('Frequencies vector is empty');
+end
+if (s1(1) ~= s2(1))
+        error('There must be equal number of frequency and magnitude data');
+end
+if (s1(2) ~= s2(2))
+        error('There must be equal number of points in frequency, magnitude, and group delay data');
+end
+if sum(s3) == 0
+        gd_s0 = zeros(s2(1),s2(2));
+end
+for i=1:s1(1)
+        [f_hz(i,:), m_db(i,:), gd_s(i,:)] = fix_response_dcnyquist(...
+                f_hz0(i,:), m_db0(i,:), gd_s0(i,:), fs);
+end
+
+end
+
+function [f_hz, m_db, gd_s] = map_to_logfreq(f_hz0, m_db0, gd_s0, f1, f2, np)
+%% Create logarithmic frequency vector and interpolate
+f_hz = logspace(log10(f1),log10(f2), np);
+m_db = interp1(f_hz0, m_db0, f_hz);
+gd_s = interp1(f_hz0, gd_s0, f_hz);
+m_db(end) = m_db(end-1); % Fix NaN in the end
+gd_s(end) = gd_s(end-1); % Fix NaN in the end
+end
+
+function [f_hz, mm_db, mgd_s, num] = map_to_logfreq_mult(f_hz0, m_db0, ...
+        gd_s0, f1, f2, np)
+
+s1 = size(f_hz0);
+s2 = size(m_db0);
+s3 = size(gd_s0);
+if (s1(1) ~= s2(1))
+        error('There must be equal number of frequency and magnitude data sets');
+end
+if (s1(2) ~= s2(2))
+        error('There must be equal number of points in frequency and magnitude data');
+end
+num = s1(1);
+if sum(s3) == 0
+        gd_s0 = zeros(s2(1),s2(2));
+end
+for i=1:num
+        [f_hz, m_db(i,:), gd_s(i,:)] = map_to_logfreq(f_hz0(i,:), ...
+                m_db0(i,:), gd_s0(i,:), f1, f2, np);
+end
+
+if num > 1
+        mm_db = mean(m_db);
+        mgd_s = mean(gd_s);
+else
+        mm_db = m_db;
+        mgd_s = gd_s;
+end
+end
+
+function [ms_db, noct] = logsmooth(f, m_db, c)
+
+%% Create a 1/N octave smoothing filter
+ind1 = find(f < 1000);
+ind2 = find(f < 2000);
+noct = ind2(end)-ind1(end);
+n = 2*round(c*noct/2);
+b_smooth = ones(1,n)*1/n;
+
+%% Smooth the response
+tmp = filter(b_smooth, 1, m_db);
+ms_db = [tmp(n/2+1:end) linspace(tmp(end), m_db(end), n/2)];
+ms_db(1:n) = ones(1,n)*ms_db(n);
+end
+
+function [m_db, fmin_fir, fmax_fir] = get_fir_target(fhz, err2db, fmin_fir, ...
+        fmax_fir, amin_fir, amax_fir, noct, auto)
+
+
+%% Find maximum in 1-6 kHz band
+idx = find(fhz > 1e3, 1, 'first') - 1;
+m_db = err2db - err2db(idx);
+if auto
+        cf = [1e3 6e3];
+        ind1 = find(fhz < cf(2));
+        ind2 = find(fhz(ind1) > cf(1));
+        ipeak = find(m_db(ind2) == max(m_db(ind2))) + ind2(1);
+        ind1 = find(fhz < cf(1));
+        ind2 = find(m_db(ind1) > m_db(ipeak));
+        if length(ind2) > 0
+                fmin_fir = fhz(ind2(end));
+        end
+        ind1 = find(fhz > cf(2));
+        ind2 = find(m_db(ind1) > m_db(ipeak)) + ind1(1);
+        if length(ind2) > 0
+                fmax_fir = fhz(ind2(1));
+        end
+end
+
+%% Find FIR target response
+ind1 = find(fhz < fmin_fir);
+ind2 = find(fhz > fmax_fir);
+p1 = ind1(end)+1;
+if length(ind2) > 0
+        p2 = ind2(1)-1;
+else
+        p2 = length(fhz);
+end
+m_db(ind1) = m_db(p1);
+m_db(ind2) = m_db(p2);
+ind = find(m_db > amax_fir);
+m_db(ind) = amax_fir;
+ind = find(m_db < amin_fir);
+m_db(ind) = amin_fir;
+
+%% Smooth high frequency corner with spline
+nn = round(noct/8);
+x = [p2-nn p2-nn+1 p2+nn-1 p2+nn];
+if max(x) < length(m_db)
+        y = m_db(x);
+        xx = p2-nn:p2+nn;
+        yy = spline(x, y, xx);
+        m_db(p2-nn:p2+nn) = yy;
+end
+
+%% Smooth low frequency corner with spline
+nn = round(noct/8);
+x = [p1-nn p1-nn+1 p1+nn-1 p1+nn];
+if min(x) > 0
+        y = m_db(x);
+        xx = p1-nn:p1+nn;
+        yy = spline(x, y, xx);
+        m_db(p1-nn:p1+nn) = yy;
+end
+
+end
+
+function b = compute_linph_fir(f_hz, m_db, taps, fs, beta)
+if nargin < 5
+        beta = 4;
+end
+if mod(taps,2) == 0
+        fprintf('Warning: Even FIR length requested.\n');
+end
+n_fft = 2*2^ceil(log(taps)/log(2));
+n_half = n_fft/2+1;
+f_fft = linspace(0, fs/2, n_half);
+m_lin = 10.^(m_db/20);
+if f_hz(1) > 0
+        f_hz = [0 f_hz];
+        m_lin = [m_lin(1) m_lin];
+end
+a_half = interp1(f_hz, m_lin, f_fft, 'linear');
+a = [a_half conj(a_half(end-1:-1:2))];
+h = real(fftshift(ifft(a)));
+b0 = h(n_half-floor((taps-1)/2):n_half+floor((taps-1)/2));
+win = kaiser(length(b0), beta)';
+b = b0 .* win;
+if length(b) < taps
+        % Append to even length
+        b = [b 0];
+end
+end
+
+function b_fir = compute_minph_fir(f, m_db, fir_length, fs, beta)
+
+%% Design double length H^2 FIR
+n = 2*fir_length+1;
+m_lin2 = (10.^(m_db/20)).^2;
+m_db2 = 20*log10(m_lin2);
+blin = compute_linph_fir(f, m_db2, n, fs,  beta);
+
+%% Find zeros inside unit circle
+myeps = 1e-3;
+hdzeros = roots(blin);
+ind1 = find( abs(hdzeros) < (1-myeps) );
+minzeros = hdzeros(ind1);
+
+%% Find double zeros at unit circle
+ind2 = find( abs(hdzeros) > (1-myeps) );
+outzeros = hdzeros(ind2);
+ind3 = find( abs(outzeros) < (1+myeps) );
+circlezeros = outzeros(ind3);
+
+%% Get half of the unit circle zeros
+if isempty(circlezeros)
+        %% We are fine ...
+else
+        %% Eliminate double zeros
+        cangle = angle(circlezeros);
+        [sorted_cangle, ind] = sort(cangle);
+        sorted_czeros = circlezeros(ind);
+        pos = find(angle(sorted_czeros) > 0);
+        neg = find(angle(sorted_czeros) < 0);
+        pos_czeros = sorted_czeros(pos);
+        neg_czeros = sorted_czeros(neg(end:-1:1));
+        h1 = [];
+        for i = 1:2:length(pos_czeros)-1
+                x=mean(angle(pos_czeros(i:i+1)));
+                h1 = [h1' complex(cos(x),sin(x))]';
+        end
+        h2 = [];
+        for i = 1:2:length(neg_czeros)-1;
+                x=mean(angle(neg_czeros(i:i+1)));
+                h2 = [h2' complex(cos(x),sin(x))]';
+        end
+        halfcirclezeros = [h1' h2']';
+        if length(halfcirclezeros)*2 < length(circlezeros)-0.1
+                %% Replace the last zero pair
+                halfcirclezeros = [halfcirclezeros' complex(-1, 0)]';
+        end
+        minzeros = [ minzeros' halfcirclezeros' ]';
+end
+
+%% Convert to transfer function
+bmin = mypoly(minzeros);
+
+%% Scale peak in passhz to max m_db
+hmin = freqz(bmin, 1, 512, fs);
+b_fir = 10^(max(m_db)/20)*bmin/max(abs(hmin));
+
+end
+
+function tf = mypoly( upolyroots )
+
+% Sort roots to increasing angle to ensure more consistent behavior
+aa = abs(angle(upolyroots));
+[sa, ind] = sort(aa);
+polyroots = upolyroots(ind);
+
+n = length(polyroots);
+n1 = 16; % do not change, hardwired to 16 code below
+
+if n < (2*n1+1)
+        % No need to split
+        tf = poly(polyroots);
+else
+        % Split roots evenly to 16 poly computations
+        % The fist polys will rpb+1 roots and the rest
+        % rpb roots to compute
+        rpb = floor(n/n1);
+        rem = mod(n,n1);
+        i1 = zeros(1,n1);
+        i2 = zeros(1,n1);
+        i1(1) = 1;
+        for i = 1:n1-1;
+                if rem > 0
+                        i2(i) = i1(i)+rpb;
+                        rem = rem-1;
+                else
+                        i2(i) = i1(i)+rpb-1;
+                end
+                i1(i+1) = i2(i)+1;
+        end
+        i2(n1) = n;
+        tf101 = poly(polyroots(i1(1):i2(1)));
+        tf102 = poly(polyroots(i1(2):i2(2)));
+        tf103 = poly(polyroots(i1(3):i2(3)));
+        tf104 = poly(polyroots(i1(4):i2(4)));
+        tf105 = poly(polyroots(i1(5):i2(5)));
+        tf106 = poly(polyroots(i1(6):i2(6)));
+        tf107 = poly(polyroots(i1(7):i2(7)));
+        tf108 = poly(polyroots(i1(8):i2(8)));
+        tf109 = poly(polyroots(i1(9):i2(9)));
+        tf110 = poly(polyroots(i1(10):i2(10)));
+        tf111 = poly(polyroots(i1(11):i2(11)));
+        tf112 = poly(polyroots(i1(12):i2(12)));
+        tf113 = poly(polyroots(i1(13):i2(13)));
+        tf114 = poly(polyroots(i1(14):i2(14)));
+        tf115 = poly(polyroots(i1(15):i2(15)));
+        tf116 = poly(polyroots(i1(16):i2(16)));
+        % Combine coefficients with convolution
+        tf21 = conv(tf101, tf116);
+        tf22 = conv(tf102, tf115);
+        tf23 = conv(tf103, tf114);
+        tf24 = conv(tf104, tf113);
+        tf25 = conv(tf105, tf112);
+        tf26 = conv(tf106, tf111);
+        tf27 = conv(tf107, tf110);
+        tf28 = conv(tf108, tf109);
+        tf31 = conv(tf21, tf28);
+        tf32 = conv(tf22, tf27);
+        tf33 = conv(tf23, tf26);
+        tf34 = conv(tf24, tf25);
+        tf41 = conv(tf31, tf34);
+        tf42 = conv(tf32, tf33);
+        tf   = conv(tf41, tf42);
+
+        % Ensure the tf coefficents are real if rounding issues
+        tf = real(tf);
+end
+
+end

--- a/tune/eq/eq_compute_response.m
+++ b/tune/eq/eq_compute_response.m
@@ -1,0 +1,45 @@
+function [m, ph, gd] = eq_compute_response(b, a, f, fs)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+h = freqz(b, a, f, fs);
+m = 20*log10(abs(h));
+ph = 180/pi*angle(h);
+
+lb = length(b);
+la = length(a);
+if lb == 1 && la == 1
+	gd = zeros(1, length(f));
+else
+	gd = 1/fs*grpdelay(b, a, f, fs);
+end
+
+end

--- a/tune/eq/eq_compute_tot_response.m
+++ b/tune/eq/eq_compute_tot_response.m
@@ -1,0 +1,50 @@
+function eq = eq_compute_tot_response(eq)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+% FIR response and combined IIR+FIR EQ
+[eq.iir_eq_db, eq.iir_eq_ph, eq.iir_eq_gd] = eq_compute_response(eq.b_p, eq.a_p, eq.f, eq.fs);
+[eq.fir_eq_db, eq.fir_eq_ph, eq.fir_eq_gd] = eq_compute_response(eq.b_fir, 1, eq.f, eq.fs);
+eq.tot_eq_db = eq.iir_eq_db + eq.fir_eq_db;
+eq.tot_eq_gd = eq.iir_eq_gd + eq.fir_eq_gd;
+
+% Simulated equalized result
+eq.m_eqd = eq.m_db + eq.tot_eq_db; % Simulated response
+eq.m_eqd_s = eq.m_db_s + eq.tot_eq_db; % Smoothed simulated response
+eq.gd_eqd = eq.gd_s' + eq.tot_eq_gd;
+
+% Align
+[eq.m_eqd_s, adjust, p] = eq_align(eq.f, eq.m_eqd_s, eq.f_align, eq.db_align);
+eq.m_eqd = eq.m_eqd + adjust;
+eq.m_eq_loss = eq.tot_eq_db(p);
+eq.m_eqd_abs = eq.m_db_abs+eq.m_eq_loss;
+
+end

--- a/tune/eq/eq_defaults.m
+++ b/tune/eq/eq_defaults.m
@@ -1,0 +1,111 @@
+function p = eq_defaults
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+% Misc
+p.plot_figs = 0;
+p.fn = 'configuration.txt';
+p.fs = 48e3;
+p.f_align = 997;
+p.db_align = 0;
+p.logsmooth_plot = 1/3; % Smooth over 1/3 octaves
+p.logsmooth_eq = 1/3; % Smooth over 1/3 octaves
+p.np_fine = 5000; % 5000 point design grid
+
+% Parametric EQ IDs
+p.PEQ_HP1 = 1; p.PEQ_HP2 = 2; p.PEQ_LP1 = 3; p.PEQ_LP2 = 4;
+p.PEQ_LS1 = 5; p.PEQ_LS2 = 6; p.PEQ_HS1 = 7; p.PEQ_HS2 = 8;
+p.PEQ_PN2 = 9; p.PEQ_LP4 = 10; p.PEQ_HP4 = 11;
+
+% FIR constraints
+p.fmin_fir = 200; %
+p.fmax_fir = 15e3; %
+p.amax_fir =  20;
+p.amin_fir = -20;
+p.fir_beta = 8;
+p.fir_length = 63;
+p.fir_minph = 0; % 0 = linear phase, 1 = minimum phase
+% Adjust fmin_fir, fmax_fir automatically for least gain loss in FIR
+p.fir_autoband = 1;
+p.enable_fir = 1;
+
+% IIR conf
+p.iir_biquads_max = 6;
+p.enable_iir = 0;
+
+% Initialize other fields those are computed later to allow use of struct
+% arrays
+p.raw_f = [10 100e3];
+p.raw_m_db = [0 0];
+p.raw_gd_s = [];
+p.f = [];
+p.m_db = [];
+p.gd_s = [];
+p.num_responses = 0;
+p.m_db_s = [];
+p.gd_s_s = [];
+p.logsmooth_noct = 0;
+p.b_t = [];
+p.a_t = [];
+p.t_db = [];
+p.m_db_abs = 0;
+p.m_db_offs = 0;
+p.raw_m_noalign_db = [];
+p.err_db = [];
+p.b_p = 0;
+p.a_p = 0;
+p.iir_eq_db = [];
+p.iir_eq_ph = [];
+p.iir_eq_gd = [];
+p.err2_db = [];
+p.t_fir_db = [];
+p.b_fir = [];
+p.fir_eq_db = [];
+p.fir_eq_ph = [];
+p.fir_eq_gd = [];
+p.tot_eq_db = [];
+p.tot_eq_gd = [];
+p.m_eqd = [];
+p.gd_eqd = [];
+p.m_eq_loss = 0;
+p.m_eqd_abs = 0;
+p.sim_m_db = [];
+p.parametric_target_response = [];
+p.target_f = [10 100e3];
+p.target_m_db = [0 0];
+p.fir_compensate_iir = 1;
+p.p_fmin = 10;
+p.p_fmax = 30e3;
+p.name = '';
+p.norm_type = 'loudness'; % loudness/peak/1k
+p.norm_offs_db = 1;
+
+end

--- a/tune/eq/eq_define_parametric_eq.m
+++ b/tune/eq/eq_define_parametric_eq.m
@@ -1,0 +1,137 @@
+function [b_t, a_t] = eq_define_parametric_eq(peq, fs)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+% Parametric types
+PEQ_HP1 = 1; PEQ_HP2 = 2; PEQ_LP1 = 3; PEQ_LP2 = 4;
+PEQ_LS1 = 5; PEQ_LS2 = 6; PEQ_HS1 = 7; PEQ_HS2 = 8;
+PEQ_PN2 = 9; PEQ_LP4 = 10; PEQ_HP4 = 11;
+
+%figure(100);
+%fv = logspace(log10(20),log10(20e3),500);
+%hold on;
+sp = size(peq);
+b_t = 1; a_t = 1;
+for i=1:sp(1)
+        type = peq(i,1);
+        f = peq(i,2);
+        g = peq(i,3);
+        bw = peq(i,4);
+        if f < fs/2
+                switch peq(i,1)
+                        case PEQ_HP1, [b0, a0] = butter(1, 2*f/fs, 'high');
+                        case PEQ_HP2, [b0, a0] = butter(2, 2*f/fs, 'high');
+                        case PEQ_HP4, [b0, a0] = butter(4, 2*f/fs, 'high');
+                        case PEQ_LP1, [b0, a0] = butter(1, 2*f/fs);
+                        case PEQ_LP2, [b0, a0] = butter(2, 2*f/fs);
+                        case PEQ_LP4, [b0, a0] = butter(4, 2*f/fs);
+                        case PEQ_LS1, [b0, a0] = low_shelf_1st(f, g, fs);
+                        case PEQ_LS2, [b0, a0] = low_shelf_2nd(f, g, fs);
+                        case PEQ_HS1, [b0, a0] = high_shelf_1st(f, g, fs);
+                        case PEQ_HS2, [b0, a0] = high_shelf_2nd(f, g, fs);
+                        case PEQ_PN2, [b0, a0] = peak_2nd(f, g, bw, fs);
+                        otherwise
+                                error('Unknown parametric EQ type');
+                end
+                %h = freqz(b0, a0, fv, fs);
+                %semilogx(fv, 20*log10(abs(h)),'g--');
+                b_t=conv(b_t, b0); a_t = conv(a_t, a0);
+        end
+end
+%h = freqz(b_t, a_t, fv, fs);
+%semilogx(fv, 20*log10(abs(h)),'b');
+%hold off; grid on; axis([20 20e3 -1 12]);
+%xlabel('Frequency (Hz)'); ylabel('Magnitude (dB)');
+%print -dpng peq.png;
+end
+
+function [b, a] = low_shelf_1st(fhz, gdb, fs)
+zw = 2*pi*fhz;
+w = wmap(zw, fs);
+glin = 10^(gdb/20);
+bs = [1 glin*w];
+as = [1 w];
+[b, a] = my_bilinear(bs, as, fs);
+end
+
+function [b, a] = low_shelf_2nd(fhz, gdb, fs)
+zw = 2*pi*fhz;
+w = wmap(zw, fs);
+glin = 10^(gdb/20);
+bs = [1 w*sqrt(2*glin) glin*w^2];
+as = [1 w*sqrt(2) w^2];
+[b, a] = my_bilinear(bs, as, fs);
+end
+
+function [b, a] = high_shelf_1st(fhz, gdb, fs)
+zw = 2*pi*fhz;
+w = wmap(zw, fs);
+glin = 10^(gdb/20);
+bs = [glin w];
+as = [1 w];
+[b, a] = my_bilinear(bs, as, fs);
+end
+
+function [b, a] = high_shelf_2nd(fhz, gdb, fs)
+zw = 2*pi*fhz;
+w = wmap(zw, fs);
+glin = 10^(gdb/20);
+bs = [glin w*sqrt(2*glin) w^2];
+as = [1 w*sqrt(2) w^2];
+[b, a] = my_bilinear(bs, as, fs);
+end
+
+
+function [b, a] = peak_2nd(fhz, gdb, Q, fs)
+	% Reference http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt
+	A = 10^(gdb/40); % Square root of linear gain
+	wc = 2*pi*fhz/fs;
+	alpha = sin(wc)/(2*Q);
+	b0 = 1 + alpha * A;
+	b1 = -2 * cos(wc);
+	b2 = 1 - alpha * A;
+	a0 = 1 + alpha / A;
+	a1 = -2 * cos(wc);
+	a2 = 1 - alpha / A;
+	b = [b0 / a0 b1 / a0 b2 / a0];
+	a = [1 a1 / a0 a2 / a0];
+end
+
+
+function [b, a] = my_bilinear(sb, sa, fs)
+t = 1/fs;
+[b, a] = bilinear(sb, sa, t);
+end
+
+function sw = wmap(w, fs)
+t = 1/fs;
+sw = 2/t*tan(w*t/2);
+end

--- a/tune/eq/eq_fir_blob_merge.m
+++ b/tune/eq/eq_fir_blob_merge.m
@@ -1,0 +1,50 @@
+function bs = eq_fir_blob_merge(platform_max_channels, ...
+        number_of_responses_defined, assign_response, all_coefficients);
+
+%% Merge equalizer definition into a struct used by successive blob making
+%  functions.
+%
+% bs = eq_fir_blob_merge(platform_max_channels, number_of_responses_defined, ...
+%        assign_response, all_coefficients);
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+if length(assign_response) ~= platform_max_channels
+	error("Incorrect length in EQ assign vector!");
+end
+
+bs.platform_max_channels = platform_max_channels;
+bs.number_of_responses_defined = number_of_responses_defined;
+bs.assign_response = assign_response;
+bs.all_coefficients = all_coefficients;
+
+end

--- a/tune/eq/eq_fir_blob_pack.m
+++ b/tune/eq/eq_fir_blob_pack.m
@@ -1,0 +1,139 @@
+function blob8 = eq_fir_blob_pack(bs, endian)
+
+%% Pack equalizer struct to bytes
+%
+% blob8 = eq_fir_blob_pack(bs, endian)
+% bs - blob struct
+% endian - optional, use 'little' or 'big'. Defaults to little.
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+if nargin < 2
+	endian = 'little';
+end
+
+%% Endiannes of blob
+switch lower(endian)
+        case 'little'
+                sh16 = [0 -8];
+                sh32 = [0 -8 -16 -24];
+        case 'big'
+                sh16 = [-8 0];
+                sh32 = [-24 -16 -8 0];
+        otherwise
+                error('Unknown endiannes');
+end
+
+%% Channels count must be even
+if mod(bs.platform_max_channels, 2) > 0
+	error("Channels # must be even");
+end
+
+%% Channels cound and assign vector length must be the same
+if bs.platform_max_channels ~= length( bs.assign_response)
+	bs
+	error("Channels # and response assign length must match");
+end
+
+%% Coefficients vector length must be multiple of 4
+len = length(bs.all_coefficients);
+len_no_header = len - 2 * bs.number_of_responses_defined;
+if mod(len_no_header, 4) > 0
+	bs
+	error("Coefficient data vector length must be multiple of 4");
+end
+
+%% Pack as 16 bits
+nh16 = 4+bs.platform_max_channels;
+h16 = zeros(1, nh16, 'int16');
+h16(3) = bs.platform_max_channels;
+h16(4) = bs.number_of_responses_defined;
+for i=1:bs.platform_max_channels
+        h16(4+i) = bs.assign_response(i);
+end
+
+%% Merge header and coefficients, make even number of int16 to make it
+%  multiple of int32
+nc16 = length(bs.all_coefficients);
+nb16 = ceil((nh16+nc16)/2)*2;
+blob16 = zeros(1,nb16, 'int16');
+blob16(1:nh16) = h16;
+blob16(nh16+1:nh16+nc16) = int16(bs.all_coefficients);
+
+%% Print as 16 bit hex
+nl = ceil(nb16/16);
+for i = 1:nl
+	m = min(16, nb16-(i-1)*16);
+	for j = 1:m
+		k = (i-1)*16 + j;
+		v =  int32(blob16(k));
+		if v < 0
+			v = 65536+v;
+		end
+		fprintf(1, "%04x ", v);
+	end
+	fprintf(1, "\n");
+end
+fprintf(1, "\n");
+
+
+%% Pack as 8 bits
+nb8 = length(blob16)*2;
+blob8 = zeros(1, nb8, 'uint8');
+j = 1;
+for i = 1:length(blob16)
+        blob8(j:j+1) = w16b(blob16(i), sh16);
+        j = j+2;
+end
+
+%% Add size into first four bytes
+blob8(1:4) = w32b(nb8, sh32);
+
+%% Done
+fprintf('Blob size is %d bytes.\n', nb8);
+
+end
+
+
+function bytes = w16b(word, sh)
+bytes = uint8(zeros(1,2));
+bytes(1) = bitand(bitshift(word, sh(1)), 255);
+bytes(2) = bitand(bitshift(word, sh(2)), 255);
+end
+
+function bytes = w32b(word, sh)
+bytes = uint8(zeros(1,4));
+bytes(1) = bitand(bitshift(word, sh(1)), 255);
+bytes(2) = bitand(bitshift(word, sh(2)), 255);
+bytes(3) = bitand(bitshift(word, sh(3)), 255);
+bytes(4) = bitand(bitshift(word, sh(4)), 255);
+end

--- a/tune/eq/eq_fir_blob_quant.m
+++ b/tune/eq/eq_fir_blob_quant.m
@@ -1,0 +1,89 @@
+function fbr = eq_fir_blob_quant(b, bits)
+
+%% Quantize FIR coefficients and return vector with length,
+%  out shift, and coefficients to be used in the setup blob.
+%
+%  fbr = eq_fir_blob_resp(b, bits)
+%  b - FIR coefficients
+%  bits - optional number of bits, defaults to 16
+%
+%  fbr - vector with length, in shift, out shift, and quantized coefficients
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+if nargin < 2
+	bits = 16;
+end
+
+[bq, shift] = eq_fir_quantize(b, bits);
+
+nb = length(bq);
+mod4 = mod(nb, 4);
+if mod4 > 0
+	pad = zeros(1,4-mod4);
+	bqp = [bq pad];
+	nnew = length(bqp);
+	fprintf(1,'Note: Filter length was %d, padded length into %d,\n', nb, nnew);
+else
+	nnew = nb;
+	bqp = bq;
+end
+
+fbr = [nnew shift bqp];
+
+end
+
+function [bq, shift] = eq_fir_quantize(b, bits)
+
+% [bq, shift] = eq_fir_quantize(b, bits)
+%
+% Inputs
+% b - FIR coefficients
+% bits - number bits for 2s complement coefficient
+%
+% Outputs
+% bq - quantized coefficients
+% shift - shift right parameter to apply after FIR computation to
+% compensate for coefficients scaling
+%
+
+scale = 2^(bits-1);
+
+%% Output shift for coefficients
+m = max(abs(b));
+shift = -ceil(log(m+1/scale)/log(2));
+bsr = b*2^shift;
+
+%% Quantize to Q1.bits-1 format, e.g. Q1.15 for 16 bits
+bq = eq_coef_quant(bsr, bits, bits-1);
+
+end

--- a/tune/eq/eq_iir_blob_merge.m
+++ b/tune/eq/eq_iir_blob_merge.m
@@ -1,0 +1,52 @@
+function bs = eq_iir_blob_merge(platform_max_channels, ...
+        number_of_responses_defined, ...
+        assign_response, ...
+        all_coefficients);
+
+%% Merge equalizer definition into a struct used by successive blob making
+%  functions.
+%
+% bs = eq_iir_blob_merge(platform_max_channels, number_of_responses_defined, ...
+%        assign_response, all_coefficients);
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+if length(assign_response) ~= platform_max_channels
+	error("Assign response does not match channels count!");
+end
+
+bs.platform_max_channels = platform_max_channels;
+bs.number_of_responses_defined = number_of_responses_defined;
+bs.assign_response = assign_response;
+bs.all_coefficients = all_coefficients;
+
+end

--- a/tune/eq/eq_iir_blob_pack.m
+++ b/tune/eq/eq_iir_blob_pack.m
@@ -1,0 +1,84 @@
+function blob8 = eq_iir_blob_pack(bs, endian)
+
+%% Pack equalizer struct to bytes
+%
+% blob8 = eq_iir_blob_pack(bs, endian)
+% bs - blob struct
+% endian - optional, use 'little' or 'big'. Defaults to little.
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+if nargin < 2
+	endian = 'little';
+end
+
+%% Shift values for little/big endian
+switch lower(endian)
+        case 'little'
+                sh = [0 -8 -16 -24];
+        case 'big'
+                sh = [-24 -16 -8 0];
+        otherwise
+                error('Unknown endiannes');
+end
+
+%% Pack as 8 bits, header
+nbytes_head = (3+bs.platform_max_channels)*4;
+nbytes_coef = length(bs.all_coefficients)*4;
+nbytes = nbytes_head + nbytes_coef;
+blob8 = uint8(zeros(1,nbytes));
+
+j = 1;
+blob8(j:j+3) = w2b(nbytes, sh); j=j+4;
+blob8(j:j+3) = w2b(bs.platform_max_channels, sh); j=j+4;
+blob8(j:j+3) = w2b(bs.number_of_responses_defined, sh); j=j+4;
+
+for i=1:bs.platform_max_channels
+        blob8(j:j+3) = w2b(bs.assign_response(i), sh); j=j+4;
+end
+
+%% Pack coefficients
+for i=1:length(bs.all_coefficients)
+        blob8(j:j+3) = w2b(bs.all_coefficients(i), sh); j=j+4;
+end
+fprintf('Blob size is %d bytes.\n', nbytes);
+
+
+end
+
+function bytes = w2b(word, sh)
+bytes = uint8(zeros(1,4));
+bytes(1) = bitand(bitshift(word, sh(1)), 255);
+bytes(2) = bitand(bitshift(word, sh(2)), 255);
+bytes(3) = bitand(bitshift(word, sh(3)), 255);
+bytes(4) = bitand(bitshift(word, sh(4)), 255);
+end

--- a/tune/eq/eq_iir_blob_quant.m
+++ b/tune/eq/eq_iir_blob_quant.m
@@ -1,0 +1,115 @@
+function iir_resp = eq_iir_blob_quant(eq_b, eq_a)
+
+%% Convert IIR coefficients to 2nd order sections and quantize
+%
+%  iir_resp = eq_iir_blob_quant(b, a, bits)
+%
+%  b - numerator coefficients
+%  a - denominator coefficients
+%  bits - number of bits to quantize
+%
+%  iir_resp - vector to setup an IIR equalizer with number of sections, shifts,
+%  and quantized coefficients
+%
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Settings
+bits_iir = 32; % Q2.30
+qf_iir = 30;
+bits_gain = 16; % Q2.14
+qf_gain = 14;
+scale_max = -3; % dB, scale biquad L-inf norm
+plot_pz = 0;
+plot_fr = 0;
+
+%% Convert IIR to 2nd order sections
+[sos, gain] = tf2sos(eq_b , eq_a);
+sz = size(sos);
+nbr_sections = sz(1);
+n_section_header = 2;
+n_section = 7;
+iir_resp = int32(zeros(1,n_section_header+nbr_sections*n_section));
+iir_resp(1) = nbr_sections;
+iir_resp(2) = nbr_sections; % Note: All sections in series
+
+for n=1:nbr_sections
+        b = sos(n,1:3);
+        a = sos(n,4:6);
+
+        if plot_pz
+                figure
+                zplane(b,a);
+                tstr = sprintf('SOS %d poles and zeros', n);
+                title(tstr);
+        end
+
+        np = 1024;
+        [h, w] = freqz(b, a, np);
+        hm = max(abs(h));
+        scale = 10^(scale_max/20)/hm;
+        gain_remain = 1/scale;
+        gain = gain*gain_remain;
+        b = b * scale;
+
+        ma = max(abs(a));
+        mb = max(abs(b));
+
+        if plot_fr
+                figure
+                [h, w] = freqz(b, a, np);
+                plot(w, 20*log10(abs(h))); grid on;
+                xlabel('Frequency (w)');
+                ylabel('Magnitude (dB)');
+                tstr = sprintf('SOS %d frequency response', n);
+                title(tstr);
+        end
+
+        %% Apply remaining gain at last section output
+        if n == nbr_sections
+                section_shift = -fix(log(gain)/log(2));
+                section_gain= gain/2^(-section_shift);
+        else
+                section_shift = 0;
+                section_gain = 1;
+        end
+
+        %% Note: Invert sign of a!
+        %% Note:  a(1) is omitted, it's always 1
+        m = n_section_header+(n-1)*n_section+1;
+        iir_resp(m:m+1) = eq_coef_quant(-a(3:-1:2), bits_iir, qf_iir);
+        iir_resp(m+2:m+4) =  eq_coef_quant( b(3:-1:1), bits_iir, qf_iir);
+        iir_resp(m+5) = section_shift;
+        iir_resp(m+6) = eq_coef_quant( section_gain, bits_gain, qf_gain);
+
+end
+
+end

--- a/tune/eq/eq_norm.m
+++ b/tune/eq/eq_norm.m
@@ -1,0 +1,114 @@
+function eq = eq_norm(eq)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Normalize loudness of EQ by computing weighted average of linear
+%  response. Find scale need to make the average one.
+w_lin = level_norm_fweight(eq.f);
+m_lin_fir = 10.^(eq.fir_eq_db/20);
+m_lin_iir = 10.^(eq.iir_eq_db/20);
+i1k = find(eq.f > 1e3, 1, 'first') - 1;
+m_max_fir = max(eq.fir_eq_db);
+m_max_iir = max(eq.iir_eq_db);
+sens_fir = sum(m_lin_fir.*w_lin)/sum(w_lin);
+sens_iir = sum(m_lin_fir.*w_lin)/sum(w_lin);
+g_offs = 10^(eq.norm_offs_db/20);
+
+%% Determine scaling gain
+switch lower(eq.norm_type)
+        case 'loudness'
+                g_fir = 1/sens_fir;
+                g_iir = 1/sens_iir;
+        case '1k'
+                g_fir = 1/m_lin_fir(i1k);
+                g_iir = 1/m_lin_iir(i1k);
+
+        case 'peak'
+                g_fir = 10^(-m_max_fir/20);
+                g_iir = 10^(-m_max_iir/20);
+        otherwise
+                error('Requested normalization is not supported');
+end
+
+%% Adjust FIR and IIR gains if enabled
+if eq.enable_fir && eq.enable_iir
+        eq.b_fir = eq.b_fir * g_fir * g_offs;
+        eq.b_p = eq.b_p * g_iir * g_offs;
+end
+if eq.enable_fir && eq.enable_iir == 0
+        eq.b_fir = eq.b_fir * g_fir * g_offs;
+end
+if eq.enable_fir == 0 && eq.enable_iir
+        eq.b_p = eq.b_p * g_iir * g_offs;
+end
+
+%% Re-compute response after adjusting gain
+eq = eq_compute_tot_response(eq);
+
+end
+
+function m_lin = level_norm_fweight(f)
+
+%% w_lin = level_norm_fweight(f)
+%
+% Provides frequency weight that is useful in normalization of
+% loudness of effect like equalizers. The weight consists of pink noise
+% like spectral shape that attenuates higher frequencies 3 dB per
+% octave. The low frequencies are shaped by 2nd order high-pass
+% response at 20 Hz and higher frequencies by 3rd order low-pass at 20
+% kHz.
+%
+% Note: This weight may have similarity with a standard defined test signal
+% characteristic for evaluating music player output levels but this is not
+% an implementation of it. This weight may help in avoiding a designed EQ to
+% exceed safe playback levels in othervise compliant device.
+%
+% Input f - frequencies vector in Hz
+%
+% Output w_lin  - weight curve, aligned to peak of 1.0 in the requested f
+%
+
+[z_hp, p_hp] = butter(2, 22.4,'high','s');
+[z_lp, p_lp] = butter(3, 22.4e3,'s');
+z_bp = conv(z_hp, z_lp);
+p_bp = conv(p_hp, p_lp);
+h = freqs(z_bp, p_bp, f);
+m0 = 20*log10(abs(h));
+noct = log(max(f)/min(f))/log(2);
+att = 3*noct;
+nf = length(f);
+w = zeros(1,nf);
+w = w - linspace(0,att,nf);
+m = m0 + w;
+m = m-max(m);
+m_lin = 10.^(m/20);
+
+end

--- a/tune/eq/eq_plot.m
+++ b/tune/eq/eq_plot.m
@@ -1,0 +1,172 @@
+function eq_plot(eq, fn)
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Raw measured response
+if length(eq.raw_m_db) > 2
+        % Raw without EQ
+        fh=figure(fn); fn = fn+1;
+	f1 = min(eq.raw_f);
+	f2 = max(eq.raw_f);
+	i1 = find(eq.f > f1, 1, 'first') - 1;
+	i2 = find(eq.f > f2, 1, 'first') - 1;
+	idx = i1:i2;
+        semilogx(eq.f(idx), eq.m_db(idx), eq.f(idx), eq.m_db_s(idx));
+        grid on;
+        ax=axis; axis([eq.p_fmin eq.p_fmax min(max(ax(3:4), -40), 20)]);
+        legend('Raw','Smoothed');
+        xlabel('Frequency (Hz)');
+        ylabel('Magnitude (dB)');
+        tstr = sprintf('Imported frequency response: %s', eq.name);
+        title(tstr);
+
+        % Simulated with EQ
+        fh=figure(fn); fn = fn+1;
+        semilogx(eq.f(idx), eq.m_eqd(idx), eq.f(idx), eq.m_eqd_s(idx));
+        grid on;
+        ax=axis; axis([eq.p_fmin eq.p_fmax min(max(ax(3:4), -40), 20)]);
+        legend('Raw','Smoothed');
+        xlabel('Frequency (Hz)');
+        ylabel('Magnitude (dB)');
+        tstr = sprintf('Simulated frequency response: %s', eq.name);
+        title(tstr);
+end
+
+%% Filter responses
+fh=figure(fn); fn = fn+1;
+i1k = find(eq.f > 1e3, 1, 'first') - 1;
+offs_tot = -eq.tot_eq_db(i1k);
+offs_fir = -eq.fir_eq_db(i1k);
+offs_iir = -eq.iir_eq_db(i1k);
+if eq.enable_fir && eq.enable_iir
+        semilogx(eq.f, eq.err_db_s, eq.f, eq.tot_eq_db + offs_tot, ...
+                eq.f, eq.iir_eq_db + offs_iir, '--',...
+                eq.f, eq.fir_eq_db + offs_fir, '--');
+        legend('Target', 'Combined', 'IIR', 'FIR', 'Location', 'NorthWest');
+end
+if eq.enable_fir && eq.enable_iir == 0
+        semilogx(eq.f, eq.err_db_s, eq.f, eq.fir_eq_db + offs_fir);
+        legend('Target', 'FIR', 'Location', 'NorthWest');
+end
+if eq.enable_fir == 0 && eq.enable_iir
+        semilogx(eq.f, eq.err_db_s, eq.f, eq.iir_eq_db + offs_iir);
+        legend('Target', 'IIR', 'Location', 'NorthWest');
+end
+grid on;
+ax=axis; axis([eq.p_fmin eq.p_fmax min(max(ax(3:4), -40), 40)]);
+xlabel('Frequency (Hz)');
+ylabel('Magnitude (dB)');
+tstr = sprintf('Filter target vs. achieved response: %s', eq.name);
+title(tstr);
+
+%% FIR filter
+if length(eq.b_fir) > 1
+        % Response
+	fh=figure(fn); fn = fn+1;
+	semilogx(eq.f, eq.fir_eq_db);
+	grid on;
+	xlabel('Frequency (Hz)');
+	ylabel('Magnitude (dB)');
+        ax = axis; axis([eq.p_fmin eq.p_fmax max(ax(3:4), -40)]);
+        tstr = sprintf('FIR filter normalized response: %s', eq.name);
+        title(tstr);
+
+        % Impulse response / coefficients
+        fh=figure(fn); fn = fn+1;
+	stem(eq.b_fir);
+	grid on;
+	xlabel('Coefficient #');
+	ylabel('Coefficient value');
+        tstr = sprintf('FIR filter impulse response: %s', eq.name);
+        title(tstr);
+
+end
+
+%% IIR filter
+if length(eq.b_p) > 1
+        % Response
+	fh=figure(fn); fn = fn+1;
+	semilogx(eq.f, eq.iir_eq_db);
+	grid on;
+	xlabel('Frequency (Hz)');
+	ylabel('Magnitude (dB)');
+        ax = axis; axis([eq.p_fmin eq.p_fmax max(ax(3:4), -40)]);
+        tstr = sprintf('IIR filter normalized response: %s', eq.name);
+        title(tstr);
+
+        % Polar
+        fh=figure(fn); fn = fn+1;
+        zplane(eq.b_p, eq.a_p);
+        grid on;
+        tstr = sprintf('IIR zeros and poles: %s', eq.name);
+        title(tstr);
+
+        % Impulse
+        ti = 50e-3;
+        x = zeros(1, ti * round(eq.fs));
+        x(1) = 1;
+        y = filter(eq.b_p, eq.a_p, x);
+	fh=figure(fn); fn = fn+1;
+        t = (0:(length(x)-1)) / eq.fs;
+        plot(t, y);
+        grid on;
+        xlabel('Time (s)');
+        ylabel('Sample value');
+        tstr = sprintf('IIR filter impulse response: %s', eq.name);
+        title(tstr);
+end
+
+%% Group delay
+fh=figure(fn); fn = fn+1;
+if eq.enable_fir && eq.enable_iir
+        semilogx(eq.f, eq.tot_eq_gd * 1e3, ...
+                eq.f, eq.fir_eq_gd * 1e3, '--', ...
+                eq.f, eq.iir_eq_gd * 1e3, '--');
+        legend('Combined','FIR','IIR');
+end
+if eq.enable_fir && eq.enable_iir == 0
+        semilogx(eq.f, eq.fir_eq_gd * 1e3);
+        legend('FIR');
+end
+if eq.enable_fir == 0 && eq.enable_iir
+        semilogx(eq.f, eq.iir_eq_gd * 1e3);
+        legend('IIR');
+end
+grid on;
+xlabel('Frequency (Hz)');
+ylabel('Group delay (ms)');
+ax = axis; axis([eq.p_fmin eq.p_fmax ax(3:4)]);
+tstr = sprintf('Filter group delay: %s', eq.name);
+title(tstr);
+
+
+
+end

--- a/tune/eq/example_fir_eq.m
+++ b/tune/eq/example_fir_eq.m
@@ -1,0 +1,119 @@
+%% Design demo EQs and bundle them to parameter block
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+function example_fir_eq()
+
+ascii_blob_fn = 'example_fir_eq.txt';
+binary_blob_fn = 'example_fir_eq.blob';
+endian = 'little';
+fs = 48e3;
+bits = 16;
+
+%% Design FIR loudness equalizer
+eq_loud = loudness_fir_eq(fs, 1);
+
+%% Define a passthru EQ with one tap
+b_pass = 1;
+
+%% Quantize filter coefficients for both equalizers
+bq_pass = eq_fir_blob_quant(b_pass, bits);
+bq_loud = eq_fir_blob_quant(eq_loud.b_fir, bits);
+
+%% Build blob
+platform_max_channels = 4;   % Setup max 4 channels EQ
+assign_response = [1 1 1 1]; % Switch to response #1
+num_responses = 2;           % Two responses pass, loud
+bm = eq_fir_blob_merge(platform_max_channels, ...
+		       num_responses, ...
+		       assign_response, ...
+		       [ bq_pass bq_loud ]);
+
+%% Pack and write file
+bp = eq_fir_blob_pack(bm, endian);
+eq_alsactl_write(ascii_blob_fn, bp);
+eq_blob_write(binary_blob_fn, bp);
+
+end
+
+function eq = loudness_fir_eq(fs, fn)
+
+if nargin < 2
+        fn = 1;
+end
+if nargin < 1
+        fs = 48e3;
+end
+
+%% Derived from Fletcher-Munson curves for 80 and 60 phon
+f = [ 20,21,22,24,25,27,28,30,32,34,36,38,40,43,45,48,51,54,57,60,64, ...
+        68,72,76,81,85,90,96,102,108,114,121,128,136,144,153,162,171, ...
+        182,192,204,216,229,243,257,273,289,306,324,344,364,386,409, ...
+        434,460,487,516,547,580,614,651,690,731,775,821,870,922,977, ...
+        1036,1098,1163,1233,1307,1385,1467,1555,1648,1747,1851,1962, ...
+        2079,2203,2335,2474,2622,2779,2945,3121,3308,3505,3715,3937, ...
+        4172,4421,4686,4966,5263,5577,5910,6264,6638,7035,7455,7901, ...
+        8373,8873,9404,9966,10561,11193,11861,12570,13322,14118,14962, ...
+        15856,16803,17808,18872,20000];
+
+m = [ 0.00,-0.13,-0.27,-0.39,-0.52,-0.64,-0.77,-0.89,-1.02,-1.16,  ...
+        -1.31,-1.46,-1.61,-1.76,-1.91,-2.07,-2.24,-2.43,-2.64,-2.85, ...
+        -3.04,-3.21,-3.35,-3.48,-3.62,-3.78,-3.96,-4.16,-4.35,-4.54, ...
+        -4.72,-4.90,-5.08,-5.26,-5.45,-5.64,-5.83,-6.02,-6.19,-6.37, ...
+        -6.57,-6.77,-6.98,-7.19,-7.40,-7.58,-7.76,-7.92,-8.08,-8.25, ...
+        -8.43,-8.60,-8.76,-8.92,-9.08,-9.23,-9.38,-9.54,-9.69,-9.84, ...
+        -9.97,-10.09,-10.18,-10.26,-10.33,-10.38,-10.43,-10.48,-10.54, ...
+        -10.61,-10.70,-10.78,-10.85,-10.91,-10.95,-10.98,-11.02, ...
+        -11.05,-11.07,-11.10,-11.11,-11.11,-11.10,-11.10,-11.11, ...
+        -11.14,-11.17,-11.20,-11.21,-11.22,-11.21,-11.20,-11.20, ...
+        -11.21,-11.21,-11.20,-11.17,-11.11,-11.02,-10.91,-10.78, ...
+        -10.63,-10.46,-10.25,-10.00,-9.72,-9.39,-9.02,-8.62,-8.19, ...
+        -7.73,-7.25,-6.75,-6.25,-5.75,-5.28,-4.87,-4.54,-4.33,-4.30];
+
+%% Design EQ
+eq = eq_defaults();
+eq.fs = fs;
+eq.target_f = f;            % Set EQ frequency response target: frequency vector
+eq.target_m_db = m;         % Set EQ frequency response target: magnitude
+eq.fir_beta = 3.5;          % Use with care, low value can corrupt
+eq.fir_length = 107;        % Gives just < 255 bytes
+eq.fir_autoband = 0;        % Select manually frequency limits
+eq.fmin_fir = 100;          % Equalization starts from 100 Hz
+eq.fmax_fir = 20e3;         % Equalization ends at 20 kHz
+eq.fir_minph = 1;           % If no linear phase required, check result carefully if 1
+eq.norm_type = 'loudness';  % Can be loudness/peak/1k to select normalize criteria
+eq.norm_offs_db = 0;        % E.g. -1 would leave 1 dB headroom if used with peak
+eq = eq_compute(eq);
+
+%% Plot
+eq_plot(eq, fn);
+
+end

--- a/tune/eq/example_iir_eq.m
+++ b/tune/eq/example_iir_eq.m
@@ -1,0 +1,136 @@
+%% Design effect EQs and bundle them to parameter block
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+function example_iir_eq()
+
+blob_fn = 'example_iir_eq.blob';
+alsa_fn = 'example_iir_eq.txt';
+endian = 'little';
+fs = 48e3;
+
+%% Design IIR loudness equalizer
+eq_loud = loudness_iir_eq(fs, 2);
+
+%% Define a passthru IIR EQ equalizer
+b_pass = [1 0 0];
+a_pass = [1 0 0];
+
+%% Quantize and pack filter coefficients plus shifts etc.
+bq_pass = eq_iir_blob_quant(b_pass, a_pass);
+bq_loud = eq_iir_blob_quant(eq_loud.b_p, eq_loud.a_p);
+
+%% Build blob
+platform_max_channels = 4;   % Setup max 4 channels EQ
+assign_response = [1 1 1 1]; % Switch to response #1
+num_responses = 2;           % Two responses: pass, loud
+bm = eq_iir_blob_merge(platform_max_channels, ...
+		       num_responses, ...
+		       assign_response, ...
+		       [bq_pass bq_loud]);
+
+%% Pack and write file
+bp = eq_iir_blob_pack(bm);
+eq_blob_write(blob_fn, bp);
+eq_alsactl_write(alsa_fn, bp);
+
+end
+
+%%
+
+function eq = loudness_iir_eq(fs, fn)
+
+if nargin < 2
+        fn = 1;
+end
+if nargin < 1
+        fs = 48e3;
+end
+
+%% Derived from Fletcher-Munson curves for 80 and 60 phon
+f = [ 20,21,22,24,25,27,28,30,32,34,36,38,40,43,45,48,51,54,57,60,64, ...
+        68,72,76,81,85,90,96,102,108,114,121,128,136,144,153,162,171, ...
+        182,192,204,216,229,243,257,273,289,306,324,344,364,386,409, ...
+        434,460,487,516,547,580,614,651,690,731,775,821,870,922,977, ...
+        1036,1098,1163,1233,1307,1385,1467,1555,1648,1747,1851,1962, ...
+        2079,2203,2335,2474,2622,2779,2945,3121,3308,3505,3715,3937, ...
+        4172,4421,4686,4966,5263,5577,5910,6264,6638,7035,7455,7901, ...
+        8373,8873,9404,9966,10561,11193,11861,12570,13322,14118,14962, ...
+        15856,16803,17808,18872,20000];
+
+m = [ 0.00,-0.13,-0.27,-0.39,-0.52,-0.64,-0.77,-0.89,-1.02,-1.16,  ...
+        -1.31,-1.46,-1.61,-1.76,-1.91,-2.07,-2.24,-2.43,-2.64,-2.85, ...
+        -3.04,-3.21,-3.35,-3.48,-3.62,-3.78,-3.96,-4.16,-4.35,-4.54, ...
+        -4.72,-4.90,-5.08,-5.26,-5.45,-5.64,-5.83,-6.02,-6.19,-6.37, ...
+        -6.57,-6.77,-6.98,-7.19,-7.40,-7.58,-7.76,-7.92,-8.08,-8.25, ...
+        -8.43,-8.60,-8.76,-8.92,-9.08,-9.23,-9.38,-9.54,-9.69,-9.84, ...
+        -9.97,-10.09,-10.18,-10.26,-10.33,-10.38,-10.43,-10.48,-10.54, ...
+        -10.61,-10.70,-10.78,-10.85,-10.91,-10.95,-10.98,-11.02, ...
+        -11.05,-11.07,-11.10,-11.11,-11.11,-11.10,-11.10,-11.11, ...
+        -11.14,-11.17,-11.20,-11.21,-11.22,-11.21,-11.20,-11.20, ...
+        -11.21,-11.21,-11.20,-11.17,-11.11,-11.02,-10.91,-10.78, ...
+        -10.63,-10.46,-10.25,-10.00,-9.72,-9.39,-9.02,-8.62,-8.19, ...
+        -7.73,-7.25,-6.75,-6.25,-5.75,-5.28,-4.87,-4.54,-4.33,-4.30];
+
+%% Get defaults for equalizer design
+eq = eq_defaults();
+eq.fs = fs;
+eq.target_f = f;
+eq.target_m_db = m;
+eq.enable_fir = 0;
+eq.enable_iir = 1;
+eq.norm_type = 'loudness';
+eq.norm_offs_db = 0;
+
+
+%% Manually setup low-shelf and high shelf parametric equalizers
+%
+% Parametric EQs are PEQ_HP1, PEQ_HP2, PEQ_LP1, PEQ_LP2, PEQ_LS1,
+% PEQ_LS2, PEQ_HS1, PEQ_HS2 = 8, PEQ_PN2, PEQ_LP4, and  PEQ_HP4.
+%
+% Parametric EQs take as second argument the cutoff frequency in Hz
+% and as second argument a dB value (or NaN when not applicable) . The
+% Third argument is a Q-value (or NaN when not applicable).
+eq.peq = [ ...
+                 eq.PEQ_LS1 40 +2 NaN ; ...
+                 eq.PEQ_LS1 80 +3 NaN ; ...
+                 eq.PEQ_LS1 200 +3 NaN ; ...
+                 eq.PEQ_LS1 400 +3 NaN ; ...
+                 eq.PEQ_HS2 13000 +7 NaN ; ...
+         ];
+
+%% Design EQ
+eq = eq_compute(eq);
+
+%% Plot
+eq_plot(eq, fn);
+
+end

--- a/tune/eq/example_spk_eq.m
+++ b/tune/eq/example_spk_eq.m
@@ -1,0 +1,145 @@
+%% Design an example speaker equalizer with the provided sample data
+%  This equalizer by default uses a FIR and IIR components those should be
+%  both in the speaker pipeline.
+%
+%  Note that IIR should be first since the included band-pass response provides
+%  signal headroom.
+
+%%
+% Copyright (c) 2016, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Get defaults for equalizer design
+eq = eq_defaults();
+
+%% Settings for this EQ
+eq.fs = 48e3;               % Default sample rate in SOF
+eq.enable_fir = 1;          % Try enabling and disabling FIR part
+eq.enable_iir = 1;          % Try enabling and disabling IIR part
+eq.norm_type = 'loudness';  % Preserve loudness approximately
+eq.norm_offs_db = 0;        % Can be used to control gain
+eq.p_fmin = 100;            % With this data start plots from 100 Hz
+eq.p_fmax = 20e3;           % and end to 20 kHz.
+
+%% Get acousticial frequency response measurement data. This is
+%  a quite typical response for a miniature speaker. Alternatively
+%  the response could be read from spreadsheet column format that is
+%  commonly supported by audio measurement equipment. Then extract
+%  the frequency and magnitude columns. E.g.
+%
+%      data = xlsread('spkr.xlsx', 1, 'A5:B78');
+%      eq.raw_f = data(:,1);
+%      eq.raw_m_db = data(:,2);
+
+eq.raw_f = [ ...
+         298.533,  316.232,  334.971,  354.813,  375.838,  398.106,  ...
+         421.699,  446.685,  473.153,  501.186,  530.887,  562.342,  ...
+         595.663,  630.958,  668.345,  707.946,  749.895,  794.329,  ...
+         841.397,  891.252,  944.062,     1000,  1059.26,  1122.02,  ...
+          1188.5,  1258.93,  1333.52,  1412.54,  1496.24,   1584.9,  ...
+         1678.81,  1778.28,  1883.65,  1995.27,  2113.49,  2238.72,  ...
+         2371.38,  2511.89,  2660.73,  2818.39,  2985.39,  3162.28,  ...
+         3349.66,  3548.14,  3758.38,  3981.08,  4216.97,  4466.84,  ...
+         4731.52,  5011.88,  5308.85,  5623.42,  5956.63,  6309.58,  ...
+         6683.45,  7079.47,  7498.95,   7943.3,  8413.97,  8912.52,  ...
+         9440.62,    10000,  10592.6,  11220.2,    11885,  12589.3,  ...
+         13335.2,  14125.4,  14962.4,    15849,  16788.1,  17782.8,  ...
+         18836.5,  19952.7 ...
+];
+
+eq.raw_m_db = [ ...
+         58.1704,   60.074,  60.4541,  61.3079,  62.8198,  64.3749,  ...
+         65.1556,   66.512,  67.5916,  68.6344,  69.9276,  70.7658,  ...
+         71.1125,  72.0627,  73.5348,  75.4887,  77.3088,  79.1541,  ...
+         80.9627,  82.0607,   81.943,  81.2228,  81.9497,  83.1848,  ...
+         84.3375,  85.4993,  86.4642,  87.1179,  87.4424,    87.53,  ...
+         85.7425,  85.0095,  82.9405,  82.9242,  82.7327,  83.6423,  ...
+         83.2839,  82.4201,  84.1403,  84.6485,  83.9274,  83.3366,  ...
+         83.3005,  84.2598,  85.1544,   86.015,  86.6519,  87.2118,  ...
+         87.5498,  88.1742,  88.5215,  88.3801,  89.8762,  91.4418,  ...
+         93.1845,  94.3355,  95.0918,  95.0258,  94.0337,  91.1068,  ...
+         88.7303,  87.4853,  86.2916,   83.037,  79.8056,  78.2022,  ...
+         76.0341,  74.5674,  69.2288,  56.1308,   68.697,   69.687,  ...
+         68.0005,   64.698 ...
+];
+
+%% With parametric IIR EQ try to place peaking EQ at
+%  resonant frequencies 1.4 kHz and 7.5 kHz. The gain
+%  and Q values were experimented manually. Additionally
+%  The lowest and highest frequeciens below and above speaker
+%  capability are attenuated with high-pass and low-pass
+%  filtering.
+if eq.enable_iir;
+	eq.peq = [ ...
+			 eq.PEQ_HP2   100 NaN NaN; ...
+			 eq.PEQ_PN2  1480  -6 2.0; ...
+			 eq.PEQ_PN2  7600 -12 1.3; ...
+			 eq.PEQ_LP2 14500 NaN NaN; ...
+		 ];
+end
+
+%% With FIR EQ try to flatten frequency response within
+%  1 - 13 kHz frequency band.
+if eq.enable_fir
+        eq.fir_minph = 1;
+	eq.fir_beta = 4;
+	eq.fir_length = 63;
+	eq.fir_autoband = 0;
+	eq.fmin_fir = 1000;
+	eq.fmax_fir = 13e3;
+end
+
+%% Design EQ
+eq = eq_compute(eq);
+
+%% Plot
+eq_plot(eq, 1);
+
+%% Export FIR part
+platform_max_channels = 2;  % Identical two speakers
+assign_response = [0 0];    % Switch to response #0
+num_responses = 1;          % Single response
+bq_fir = eq_fir_blob_quant(eq.b_fir);
+bm_fir = eq_fir_blob_merge(platform_max_channels, ...
+		       num_responses, ...
+		       assign_response, ...
+		       [ bq_fir ]);
+bp_fir = eq_fir_blob_pack(bm_fir);
+eq_alsactl_write('example_spk_eq_fir.txt', bp_fir);
+eq_blob_write('example_spk_eq_fir.blob', bp_fir);
+
+%% Export IIR part
+bq_iir = eq_iir_blob_quant(eq.b_p, eq.a_p);
+bm_iir = eq_iir_blob_merge(platform_max_channels, ...
+		       num_responses, ...
+		       assign_response, ...
+		       [ bq_iir ]);
+bp_iir = eq_iir_blob_pack(bm_iir);
+eq_alsactl_write('example_spk_eq_iir.txt', bp_iir);
+eq_blob_write('example_spk_eq_iir.blob', bp_iir);


### PR DESCRIPTION
This patch adds support to SOFT to setup FIR and IIR equalizer types.

The examples scripts for simple FIR loudness effect, IIR loudness effect
and speaker equalization case demonstrate the usage of the tool. The
output ".txt" files will be possible to apply with alsactl to setup
the equalizers in SOF.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>