### PR TITLE
Enhance kmod scripts

### DIFF
--- a/kmod_scripts/sof_bootloop.sh
+++ b/kmod_scripts/sof_bootloop.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 MAXLOOPS=100
 COUNTER=0
 

--- a/kmod_scripts/sof_bootone.sh
+++ b/kmod_scripts/sof_bootone.sh
@@ -8,7 +8,7 @@ sleep 1
 unset FW_BOOT
 unset ERROR
 FW_BOOT=$(dmesg | grep sof-audio | grep "boot complete")
-ERROR=$(dmesg | grep sof-audio | grep "error")
+ERROR=$(dmesg | grep sof-audio | grep -v "DSP trace buffer overflow" | grep "error")
 
 if [ ! -z "$ERROR" ] || [ -z "$FW_BOOT" ]
 then

--- a/kmod_scripts/sof_bootone.sh
+++ b/kmod_scripts/sof_bootone.sh
@@ -9,10 +9,13 @@ unset FW_BOOT
 unset ERROR
 FW_BOOT=$(dmesg | grep sof-audio | grep "boot complete")
 ERROR=$(dmesg | grep sof-audio | grep -v "DSP trace buffer overflow" | grep "error")
+TIMEOUT=$(dmesg | grep sof-audio | grep "ipc timed out")
 
-if [ ! -z "$ERROR" ] || [ -z "$FW_BOOT" ]
+if [ ! -z "$ERROR" ] || [ -z "$FW_BOOT" ] || [ ! -z "$TIMEOUT" ]
 then
-   echo "boot failed"
+    dmesg > boot_fail.log
+    echo "boot failed, see boot_fail.log for details"
+    exit 1
 else
     echo "boot success"
 fi


### PR DESCRIPTION
Make sure DMA trace overflow are filtered out, and conversely trap IPC timeout errors which are quite frequent. Also stop the bootloop when a problem is hit.