### PR TITLE
RFC: topology: Add support for HDA backend DAI link configuration

### DIFF
--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -19,6 +19,7 @@ DEPS = \
 MACHINES = \
 	sof-cht-nocodec.tplg \
 	sof-cht-max98090.tplg \
+	sof-apl-hda.tplg \
 	sof-apl-nocodec.tplg \
 	sof-byt-nocodec.tplg \
 	sof-bdw-rt286.tplg \
@@ -53,6 +54,7 @@ clean-local:
 EXTRA_DIST = \
 	sof-cht-nocodec.m4 \
 	sof-cht-max98090.m4 \
+	sof-apl-hda.m4 \
 	sof-apl-nocodec.m4 \
 	sof-byt-nocodec.m4 \
 	sof-bdw-rt286.m4 \

--- a/topology/m4/dai.m4
+++ b/topology/m4/dai.m4
@@ -160,6 +160,29 @@ define(`DAI_CONFIG',
 `	]'
 `}')
 
+dnl HDA_DAI_CONFIG(idx, link_id, name)
+define(`HDA_DAI_CONFIG',
+`SectionVendorTuples."'N_DAI_CONFIG(HDA$1)`_tuples_common" {'
+`       tokens "sof_dai_tokens"'
+`       tuples."string" {'
+`               SOF_TKN_DAI_TYPE 		"HDA"'
+`       }'
+`       tuples."word" {'
+`               SOF_TKN_DAI_INDEX'              STR($1)
+`       }'
+`}'
+`SectionData."'N_DAI_CONFIG(HDA$1)`_data_common" {'
+`       tuples "'N_DAI_CONFIG(HDA$1)`_tuples_common"'
+`}'
+`'
+`SectionBE."'$3`" {'
+`       id "'$2`"'
+`       index "0"'
+`       data ['
+`               "'N_DAI_CONFIG(HDA$1)`_data_common"'
+`       ]'
+`}')
+
 dnl DAI_ADD(pipeline,
 dnl     pipe id, dai type, dai_index, dai_be,
 dnl     buffer, periods, format,

--- a/topology/sof-apl-hda.m4
+++ b/topology/sof-apl-hda.m4
@@ -1,0 +1,92 @@
+#
+# Topology for generic Apollolake board with no codec.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`ssp.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 ----> volume -----> iDisp1
+# PCM1 ----> Volume <----- iDisp2
+# PCM2 ----> volume -----> iDisp3
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s16le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s16le,
+	48, 1000, 0, 0)
+
+# Low Latency playback pipeline 3 on PCM 1 using max 2 channels of s16le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 1, 2, s16le,
+	48, 1000, 0, 0)
+
+# Low Latency playback pipeline 5 on PCM 2 using max 2 channels of s16le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	5, 2, 2, s16le,
+	48, 1000, 0, 0)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is iDisp1 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_1, 2, s16le,
+	48, 1000, 0, 0)
+
+# playback DAI is iDisp2 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	3, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_3, 2, s16le,
+	48, 1000, 0, 0)
+
+# playback DAI is iDisp3 using 2 periods
+# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	5, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_5, 2, s16le,
+	48, 1000, 0, 0)
+
+
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(Port0, 0, PIPELINE_PCM_1)
+PCM_PLAYBACK_ADD(Port1, 1, PIPELINE_PCM_3)
+PCM_PLAYBACK_ADD(Port2, 2, PIPELINE_PCM_5)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+dnl HDA_DAI_CONFIG(dai_index, link_id, name)
+HDA_DAI_CONFIG(0, 0, iDisp1)
+HDA_DAI_CONFIG(1, 1, iDisp2)
+HDA_DAI_CONFIG(2, 2, iDisp3)


### PR DESCRIPTION
I'm still not familiar with m4 now to directly revise existing DAI_CONFIG(type, idx...) to add support for HDA BE links, and it seems current HW configuration section is more suitable to SSP links but not to HD-A links. So I define a new macro HDA_DAI_CONFIG(idx, ...) for users to define HDA BE link configurations.

Later, when we're more confident about what to configure for HDA links, we can revise the implementation. Now this can provide a fast way to add HDA BE links in machine topology file. 

The patch was verified with nocodec machine driver on Leaf Hill. 