### PR TITLE
Update EQ tune scripts

### DIFF
--- a/tune/eq/eq_compute.m
+++ b/tune/eq/eq_compute.m
@@ -30,6 +30,11 @@ function eq = eq_compute( eq )
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 %
 
+%% Sanity checks
+if eq.enable_iir == 0 && eq.enable_fir == 0
+        fprintf('Warning: Nothing to do. Please enable FIR or IIR!\n');
+end
+
 %% Extrapolate response to 0..fs/2, convert to logaritmic grid, and smooth
 %  with 1/N octave filter
 eq = preprocess_responses(eq);

--- a/tune/eq/eq_defaults.m
+++ b/tune/eq/eq_defaults.m
@@ -55,7 +55,7 @@ p.fir_length = 63;
 p.fir_minph = 0; % 0 = linear phase, 1 = minimum phase
 % Adjust fmin_fir, fmax_fir automatically for least gain loss in FIR
 p.fir_autoband = 1;
-p.enable_fir = 1;
+p.enable_fir = 0;
 
 % IIR conf
 p.iir_biquads_max = 6;
@@ -106,6 +106,6 @@ p.p_fmin = 10;
 p.p_fmax = 30e3;
 p.name = '';
 p.norm_type = 'loudness'; % loudness/peak/1k
-p.norm_offs_db = 1;
+p.norm_offs_db = 0;
 
 end

--- a/tune/eq/eq_define_parametric_eq.m
+++ b/tune/eq/eq_define_parametric_eq.m
@@ -35,16 +35,13 @@ PEQ_HP1 = 1; PEQ_HP2 = 2; PEQ_LP1 = 3; PEQ_LP2 = 4;
 PEQ_LS1 = 5; PEQ_LS2 = 6; PEQ_HS1 = 7; PEQ_HS2 = 8;
 PEQ_PN2 = 9; PEQ_LP4 = 10; PEQ_HP4 = 11;
 
-%figure(100);
-%fv = logspace(log10(20),log10(20e3),500);
-%hold on;
 sp = size(peq);
 b_t = 1; a_t = 1;
 for i=1:sp(1)
         type = peq(i,1);
         f = peq(i,2);
         g = peq(i,3);
-        bw = peq(i,4);
+        Q = peq(i,4);
         if f < fs/2
                 switch peq(i,1)
                         case PEQ_HP1, [b0, a0] = butter(1, 2*f/fs, 'high');
@@ -57,20 +54,13 @@ for i=1:sp(1)
                         case PEQ_LS2, [b0, a0] = low_shelf_2nd(f, g, fs);
                         case PEQ_HS1, [b0, a0] = high_shelf_1st(f, g, fs);
                         case PEQ_HS2, [b0, a0] = high_shelf_2nd(f, g, fs);
-                        case PEQ_PN2, [b0, a0] = peak_2nd(f, g, bw, fs);
+                        case PEQ_PN2, [b0, a0] = peak_2nd(f, g, Q, fs);
                         otherwise
                                 error('Unknown parametric EQ type');
                 end
-                %h = freqz(b0, a0, fv, fs);
-                %semilogx(fv, 20*log10(abs(h)),'g--');
                 b_t=conv(b_t, b0); a_t = conv(a_t, a0);
         end
 end
-%h = freqz(b_t, a_t, fv, fs);
-%semilogx(fv, 20*log10(abs(h)),'b');
-%hold off; grid on; axis([20 20e3 -1 12]);
-%xlabel('Frequency (Hz)'); ylabel('Magnitude (dB)');
-%print -dpng peq.png;
 end
 
 function [b, a] = low_shelf_1st(fhz, gdb, fs)
@@ -125,10 +115,12 @@ function [b, a] = peak_2nd(fhz, gdb, Q, fs)
 	a = [1 a1 / a0 a2 / a0];
 end
 
-
 function [b, a] = my_bilinear(sb, sa, fs)
-t = 1/fs;
-[b, a] = bilinear(sb, sa, t);
+if exist('OCTAVE_VERSION', 'builtin')
+        [b, a] = bilinear(sb, sa, 1/fs);
+else
+        [b, a] = bilinear(sb, sa, fs);
+end
 end
 
 function sw = wmap(w, fs)

--- a/tune/eq/eq_iir_blob_quant.m
+++ b/tune/eq/eq_iir_blob_quant.m
@@ -52,7 +52,16 @@ plot_pz = 0;
 plot_fr = 0;
 
 %% Convert IIR to 2nd order sections
-[sos, gain] = tf2sos(eq_b , eq_a);
+if exist('OCTAVE_VERSION', 'builtin')
+        [sos, gain] = tf2sos(eq_b, eq_a);
+else
+        % TODO: tf2sos produces in Matlab EQs with zero output due to
+        % very high gain variations within biquad. Need to investigate if
+        % this is incorrect usage and a bug here.
+        [sos, gain] = tf2sos(eq_b, eq_a, 'UP', Inf);
+        fprintf('Warning: Problems have been seen with some IIR designs.\n');
+        fprintf('Warning: Please check the result.\n');
+end
 sz = size(sos);
 nbr_sections = sz(1);
 n_section_header = 2;

--- a/tune/eq/eq_norm.m
+++ b/tune/eq/eq_norm.m
@@ -39,7 +39,7 @@ i1k = find(eq.f > 1e3, 1, 'first') - 1;
 m_max_fir = max(eq.fir_eq_db);
 m_max_iir = max(eq.iir_eq_db);
 sens_fir = sum(m_lin_fir.*w_lin)/sum(w_lin);
-sens_iir = sum(m_lin_fir.*w_lin)/sum(w_lin);
+sens_iir = sum(m_lin_iir.*w_lin)/sum(w_lin);
 g_offs = 10^(eq.norm_offs_db/20);
 
 %% Determine scaling gain

--- a/tune/eq/eq_plot.m
+++ b/tune/eq/eq_plot.m
@@ -30,6 +30,10 @@ function eq_plot(eq, fn)
 % Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
 %
 
+if nargin < 2
+        fn = 1;
+end
+
 %% Raw measured response
 if length(eq.raw_m_db) > 2
         % Raw without EQ

--- a/tune/eq/example_fir_eq.m
+++ b/tune/eq/example_fir_eq.m
@@ -36,17 +36,16 @@ ascii_blob_fn = 'example_fir_eq.txt';
 binary_blob_fn = 'example_fir_eq.blob';
 endian = 'little';
 fs = 48e3;
-bits = 16;
 
 %% Design FIR loudness equalizer
-eq_loud = loudness_fir_eq(fs, 1);
+eq_loud = loudness_fir_eq(fs);
 
 %% Define a passthru EQ with one tap
 b_pass = 1;
 
 %% Quantize filter coefficients for both equalizers
-bq_pass = eq_fir_blob_quant(b_pass, bits);
-bq_loud = eq_fir_blob_quant(eq_loud.b_fir, bits);
+bq_pass = eq_fir_blob_quant(b_pass);
+bq_loud = eq_fir_blob_quant(eq_loud.b_fir);
 
 %% Build blob
 platform_max_channels = 4;   % Setup max 4 channels EQ
@@ -64,14 +63,7 @@ eq_blob_write(binary_blob_fn, bp);
 
 end
 
-function eq = loudness_fir_eq(fs, fn)
-
-if nargin < 2
-        fn = 1;
-end
-if nargin < 1
-        fs = 48e3;
-end
+function eq = loudness_fir_eq(fs)
 
 %% Derived from Fletcher-Munson curves for 80 and 60 phon
 f = [ 20,21,22,24,25,27,28,30,32,34,36,38,40,43,45,48,51,54,57,60,64, ...
@@ -103,17 +95,19 @@ eq = eq_defaults();
 eq.fs = fs;
 eq.target_f = f;            % Set EQ frequency response target: frequency vector
 eq.target_m_db = m;         % Set EQ frequency response target: magnitude
+eq.norm_type = 'loudness';  % Can be loudness/peak/1k to select normalize criteria
+eq.norm_offs_db = 0;        % E.g. -1 would leave 1 dB headroom if used with peak
+
+eq.enable_fir = 1;          % By default both FIR and IIR disabled, enable one
 eq.fir_beta = 3.5;          % Use with care, low value can corrupt
 eq.fir_length = 107;        % Gives just < 255 bytes
 eq.fir_autoband = 0;        % Select manually frequency limits
 eq.fmin_fir = 100;          % Equalization starts from 100 Hz
 eq.fmax_fir = 20e3;         % Equalization ends at 20 kHz
 eq.fir_minph = 1;           % If no linear phase required, check result carefully if 1
-eq.norm_type = 'loudness';  % Can be loudness/peak/1k to select normalize criteria
-eq.norm_offs_db = 0;        % E.g. -1 would leave 1 dB headroom if used with peak
 eq = eq_compute(eq);
 
 %% Plot
-eq_plot(eq, fn);
+eq_plot(eq);
 
 end

--- a/tune/eq/example_iir_eq.m
+++ b/tune/eq/example_iir_eq.m
@@ -38,7 +38,7 @@ endian = 'little';
 fs = 48e3;
 
 %% Design IIR loudness equalizer
-eq_loud = loudness_iir_eq(fs, 2);
+eq_loud = loudness_iir_eq(fs);
 
 %% Define a passthru IIR EQ equalizer
 b_pass = [1 0 0];
@@ -66,14 +66,7 @@ end
 
 %%
 
-function eq = loudness_iir_eq(fs, fn)
-
-if nargin < 2
-        fn = 1;
-end
-if nargin < 1
-        fs = 48e3;
-end
+function eq = loudness_iir_eq(fs)
 
 %% Derived from Fletcher-Munson curves for 80 and 60 phon
 f = [ 20,21,22,24,25,27,28,30,32,34,36,38,40,43,45,48,51,54,57,60,64, ...
@@ -105,11 +98,9 @@ eq = eq_defaults();
 eq.fs = fs;
 eq.target_f = f;
 eq.target_m_db = m;
-eq.enable_fir = 0;
 eq.enable_iir = 1;
 eq.norm_type = 'loudness';
 eq.norm_offs_db = 0;
-
 
 %% Manually setup low-shelf and high shelf parametric equalizers
 %
@@ -131,6 +122,6 @@ eq.peq = [ ...
 eq = eq_compute(eq);
 
 %% Plot
-eq_plot(eq, fn);
+eq_plot(eq);
 
 end


### PR DESCRIPTION
This first part of of this patch set mainly updates compatibility of equalizers tuning and setup scripts with Matlab. Previously IIR design failed totally in Matlab with incorrect non-stable designs due to difference in parameters of bilinear transform function. There is still after this an issue hitting Matlab (but not Octave) in some IIR designs. The issue in tf2sos() poles and zeros mapping to biquads needs more work to fix. Until that it's recommended to do IIR designs only with Octave.

The second part cleans up the example designs and improves the result of speaker example.
