### PR TITLE
topology: add support for wm8804

### DIFF
--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -31,6 +31,7 @@ MACHINES = \
 	sof-hsw-rt5640.tplg \
 	sof-apl-tdf8532.tplg \
 	sof-apl-pcm512x.tplg \
+	sof-apl-wm8804.tplg \
 	sof-apl-da7219.tplg \
 	sof-glk-da7219.tplg \
 	sof-icl-nocodec.tplg
@@ -65,6 +66,7 @@ EXTRA_DIST = \
 	sof-hsw-rt5640.m4 \
 	sof-apl-tdf8532.m4 \
 	sof-apl-pcm512x.m4 \
+	sof-apl-wm8804.m4 \
 	sof-apl-da7219.m4 \
 	sof-glk-da7219.m4 \
 	sof-icl-nocodec.m4

--- a/topology/sof-apl-wm8804.m4
+++ b/topology/sof-apl-wm8804.m4
@@ -1,0 +1,55 @@
+#
+# Topology for generic Apollolake UP^2 with wm8804 codec.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+include(`ssp.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+
+#
+# Define the pipelines
+#
+# PCM0 ----> volume -----> SSP5 (wm8804)
+#
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	48, 1000, 0, 0)
+
+#
+# DAIs configuration
+#
+
+# playback DAI is SSP5 using 2 periods
+# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, SSP, 5, SSP5-Codec,
+	PIPELINE_SOURCE_1, 2, s24le,
+	48, 1000, 0, 0)
+
+# PCM Low Latency, id 0
+PCM_PLAYBACK_ADD(Port5, 0, PIPELINE_PCM_1)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
+	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
+		SSP_CLOCK(bclk, 3072000, codec_master),
+		SSP_CLOCK(fsync, 48000, codec_master),
+		SSP_TDM(2, 32, 3, 3),
+		SSP_CONFIG_DATA(SSP, 5, 24)))


### PR DESCRIPTION
This SPDIF transmitter/receiver is used by the HifiBerry DIGI+ and
DIGI IO. The wm8804 operates as bit clock and frame master.

TODO in future update: add support for capture on the DIGI+ IO (this
may be done with a different topology file to avoid confusing users
with a non-working PCM capture patch)

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>