### PR TITLE
SRC test: Fix testbench execute command line plus cleanup

### DIFF
--- a/test/src_run.sh
+++ b/test/src_run.sh
@@ -29,7 +29,7 @@ fi
 
 # Run command
 CMD0=$HOST_EXE
-CMD1="-d -x $FS1 -y $FS2 -i $FN_IN -o $FN_OUT -t $TPLG -a src=libsof_${COMP}.so $CMDFMT"
+CMD1="-d -r $FS1 -R $FS2 -i $FN_IN -o $FN_OUT -t $TPLG -a src=libsof_${COMP}.so $CMDFMT"
 CMD="$CMD0 $CMD1"
 export LD_LIBRARY_PATH=$HOST_LIB
 

--- a/test/src_test.m
+++ b/test/src_test.m
@@ -3,7 +3,7 @@ function [n_fail, n_pass, n_na] = src_test(bits_in, bits_out, fs_in_list, fs_out
 %%
 % src_test - test with SRC test bench objective audio quality parameters
 %
-% src_test(fs_in, fs_out)
+% src_test(bits_in, bits_out, fs_in, fs_out)
 %
 % bits_in  - input word length
 % bits_out - output word length
@@ -456,7 +456,9 @@ else
         title(tstr);
 end
 pfn = sprintf('plots/%s_src_%d_%d.png', testacronym, t.fs1, t.fs2);
-print(pfn, '-dpng');
+% The print command caused a strange error with __osmesa_print__
+% so disable it for now until solved.
+%print(pfn, '-dpng');
 if t.close_plot_windows
 	close all;
 end


### PR DESCRIPTION
This patch fixes the command line sample rate parameters passing
into host testbench (-r & -R).

In my computer at least the print command of non-visible plots stopped
working into error so I disabled the print commant that creates PNG
graphics files. It's OK since the purpose of this script is batch testing.
The visible plot files can be enabled from SRC test script to see plots
if need for deep dive.

The patch includes also fix for text output for "help src_test". The
input and output word lengths were missing from sample command.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>