### PR TITLE
[RFC] topology: first try of m4 debug macros

### DIFF
--- a/topology/m4/dai.m4
+++ b/topology/m4/dai.m4
@@ -1,5 +1,7 @@
 divert(-1)
 
+include(`debug.m4')
+
 dnl Define macros for DAI IN/OUT widgets and DAI config
 
 dnl DAI name)
@@ -158,7 +160,9 @@ define(`DAI_CONFIG',
 `		"'N_DAI_CONFIG($1$2)`_data_common"'
 `ifelse($1, `DMIC',`		"'N_DAI_CONFIG($1$2)`_pdm_data"', `')'
 `	]'
-`}')
+`}'
+`DEBUG_DAI_CONFIG($1, $3)'
+)
 
 dnl DAI_ADD(pipeline,
 dnl     pipe id, dai type, dai_index, dai_be,
@@ -189,6 +193,7 @@ define(`DAI_ADD',
 `define(`SCHEDULE_PRIORITY', $11)'
 `define(`SCHEDULE_CORE', $12)'
 `include($1)'
+`DEBUG_DAI($3, $4)'
 )
 
 divert(0)dnl

--- a/topology/m4/debug.m4
+++ b/topology/m4/debug.m4
@@ -1,0 +1,29 @@
+divert(-1)
+
+define(`DEBUG_START',
+`ifdef(`GRAPH', `errprint(`digraph topology {
+node [color=Red,fontname=Courier]
+edge [color=Blue, style=dashed]'
+)')')
+
+define(`DEBUG_END',
+`ifdef(`GRAPH', `errprint(`}'
+)')')
+
+define(`DEBUG_GRAPH',
+`ifdef(`GRAPH', `errprint("$2"->"$1"
+)')')
+
+define(`DEBUG_DAI',
+`ifdef(`INFO', `errprint(/* note: $1 DAI ADD dai_index $2 should match the member (index) in struct dai array (firmware platform specific, usually in dai.c) */
+)')')
+
+define(`DEBUG_DAI_CONFIG',
+`ifdef(`INFO', `errprint(/* note: $1 DAI CONFIG id $2 should match the member (id) in struct snd_soc_dai_link in kernel machine driver (usually under linux/sound/soc/intel/boards/) */
+)')')
+
+define(`DEBUG_PCM_ADD',
+`ifdef(`INFO', `errprint(/* note: PCM ADD for $1 id $2 should be unique within playback or capture pcm ids*/
+)')')
+
+divert(0)dnl

--- a/topology/m4/pipeline.m4
+++ b/topology/m4/pipeline.m4
@@ -52,6 +52,7 @@ define(`PIPELINE_PCM_ADD',
 `define(`SCHEDULE_PRIORITY', $8)'
 `define(`SCHEDULE_CORE', $9)'
 `include($1)'
+`DEBUG_PCM_ADD($1, $3)'
 )
 
 dnl PIPELINE_PCM_DAI_ADD(pipeline,

--- a/topology/m4/utils.m4
+++ b/topology/m4/utils.m4
@@ -1,5 +1,7 @@
 divert(-1)
 
+include(`debug.m4')
+
 define(`concat',`$1$2')
 
 define(`STR', `"'$1`"')
@@ -24,7 +26,7 @@ dnl Memory capabilities
 define(`MEMCAPS', `pushdef(`i', $#) pushdef(`j', `1') SUM_LOOP($@)')
 
 dnl create direct DAPM/pipeline link between 2 widgets)
-define(`dapm', `"$1, , $2"')
+define(`dapm', `"$1, , $2"'`DEBUG_GRAPH($1, $2)')
 
 dnl COMP_SAMPLE_SIZE(FMT)
 define(`COMP_SAMPLE_SIZE',

--- a/topology/sof-apl-da7219.m4
+++ b/topology/sof-apl-da7219.m4
@@ -18,6 +18,8 @@ include(`sof/tokens.m4')
 include(`platform/intel/bxt.m4')
 include(`platform/intel/dmic.m4')
 
+DEBUG_START
+
 #
 # Define the pipelines
 #
@@ -138,7 +140,4 @@ VIRTUAL_DAPM_ROUTE_OUT(Capture, SSP, 0, OUT, 16)
 VIRTUAL_DAPM_ROUTE_OUT(SoC DMIC, SSP, 0, OUT, 17)
 VIRTUAL_DAPM_ROUTE_IN(codec0_in, SSP, 0, IN, 18)
 
-
-
-
-
+DEBUG_END

--- a/topology/sof-apl-pcm512x.m4
+++ b/topology/sof-apl-pcm512x.m4
@@ -17,6 +17,8 @@ include(`sof/tokens.m4')
 # Include Apollolake DSP configuration
 include(`platform/intel/bxt.m4')
 
+DEBUG_START
+
 #
 # Define the pipelines
 #
@@ -53,3 +55,5 @@ DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 32, 3, 3),
 		SSP_CONFIG_DATA(SSP, 5, 24)))
+
+DEBUG_END


### PR DESCRIPTION
This is a first try to produce some useful info for users hacking with m4 topology.

There's a new file debug.m4 with couple of simple macros to output data. These are used from dai_add, pcm_add, and graph creation.

Debug macros are using errprint to print to stderr, so you could differentiate between actual macro output and debug messaging. To get the graph printing correct, you need to surround your m4 with DEBUG_START and DEBUG_END. You can see examples in sof-apl-pcm512x.m4 and sof-apl-da7219.m4

There are currently 2 debug defines, GRAPH and INFO. GRAPH produces dot file describing the topology graph connection. INFO produces diagnostic messages mainly concerned with dai indexing.

You can invoke the debugging like this:
m4 -I m4 -I common -I platform/common --define=GRAPH sof-apl-da7219.m4 > /dev/null
m4 -I m4 -I common -I platform/common --define=INFO sof-apl-da7219.m4 > /dev/null

To produce a graph image:
m4 -I m4 -I common -I platform/common --define=GRAPH sof-apl-da7219.m4 2> test.dot
dot test.dot -Tpng -o tplg.png

INFO messages are surrounded by C-like comment markers, so you can actually push both messages to dot file without issues:
m4 -I m4 -I common -I platform/common --define=GRAPH --define= INFO sof-apl-da7219.m4 2> test.dot