### PR TITLE
EQ Tool: Output topology m4 binary control style configuration data

### DIFF
--- a/tune/eq/eq_tplg_write.m
+++ b/tune/eq/eq_tplg_write.m
@@ -1,0 +1,63 @@
+function eq_tplg_write(fn, blob8, eqtype)
+
+%%
+% Copyright (c) 2018, Intel Corporation
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are met:
+%   * Redistributions of source code must retain the above copyright
+%     notice, this list of conditions and the following disclaimer.
+%   * Redistributions in binary form must reproduce the above copyright
+%     notice, this list of conditions and the following disclaimer in the
+%     documentation and/or other materials provided with the distribution.
+%   * Neither the name of the Intel Corporation nor the
+%     names of its contributors may be used to endorse or promote products
+%     derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+% Author: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
+%
+
+%% Pad blob length to multiple of four bytes
+n_orig = length(blob8);
+n_new = ceil(n_orig/4)*4;
+blob8_new = zeros(1, n_new);
+blob8_new(1:n_orig) = blob8;
+
+%% Write blob
+fh = fopen(fn, 'w');
+nl = 8;
+fprintf(fh, '`SectionData."''N_EQ_%s($1)`_data_bytes" {''\n', ...
+       upper(eqtype));
+fprintf(fh, '`       bytes "');
+for i = 1:nl:n_new
+	if i > 1
+		fprintf(fh, '`       ');
+	end
+	for j = 0:nl-1
+		n = i + j;
+		if n < n_new
+			fprintf(fh, '0x%02x,', blob8_new(n));
+		end
+		if n == n_new
+			fprintf(fh, '0x%02x"', blob8_new(n));
+		end
+	end
+	fprintf(fh, '''\n');
+end
+fprintf(fh, '`}''\n');
+fclose(fh);
+
+end

--- a/tune/eq/example_fir_eq.m
+++ b/tune/eq/example_fir_eq.m
@@ -34,6 +34,7 @@ function example_fir_eq()
 
 ascii_blob_fn = 'example_fir_eq.txt';
 binary_blob_fn = 'example_fir_eq.blob';
+tplg_blob_fn = 'example_fir_eq.m4';
 endian = 'little';
 fs = 48e3;
 
@@ -60,6 +61,7 @@ bm = eq_fir_blob_merge(platform_max_channels, ...
 bp = eq_fir_blob_pack(bm, endian);
 eq_alsactl_write(ascii_blob_fn, bp);
 eq_blob_write(binary_blob_fn, bp);
+eq_tplg_write(tplg_blob_fn, bp, 'FIR');
 
 end
 
@@ -100,7 +102,7 @@ eq.norm_offs_db = 0;        % E.g. -1 would leave 1 dB headroom if used with pea
 
 eq.enable_fir = 1;          % By default both FIR and IIR disabled, enable one
 eq.fir_beta = 3.5;          % Use with care, low value can corrupt
-eq.fir_length = 107;        % Gives just < 255 bytes
+eq.fir_length = 136;        % Gives just < 316 bytes
 eq.fir_autoband = 0;        % Select manually frequency limits
 eq.fmin_fir = 100;          % Equalization starts from 100 Hz
 eq.fmax_fir = 20e3;         % Equalization ends at 20 kHz

--- a/tune/eq/example_iir_eq.m
+++ b/tune/eq/example_iir_eq.m
@@ -34,6 +34,7 @@ function example_iir_eq()
 
 blob_fn = 'example_iir_eq.blob';
 alsa_fn = 'example_iir_eq.txt';
+tplg_fn = 'example_iir_eq.m4';
 endian = 'little';
 fs = 48e3;
 
@@ -60,6 +61,7 @@ bm = eq_iir_blob_merge(platform_max_channels, ...
 bp = eq_iir_blob_pack(bm);
 eq_blob_write(blob_fn, bp);
 eq_alsactl_write(alsa_fn, bp);
+eq_tplg_write(tplg_fn, bp, 'IIR');
 
 end
 

--- a/tune/eq/example_spk_eq.m
+++ b/tune/eq/example_spk_eq.m
@@ -136,6 +136,7 @@ if eq.enable_fir
         bp_fir = eq_fir_blob_pack(bm_fir);
         eq_alsactl_write('example_spk_eq_fir.txt', bp_fir);
         eq_blob_write('example_spk_eq_fir.blob', bp_fir);
+	eq_tplg_write('example_spk_eq_fir.m4', bp_fir, 'FIR');
 end
 
 %% Export IIR part
@@ -148,7 +149,7 @@ if eq.enable_iir
         bp_iir = eq_iir_blob_pack(bm_iir);
         eq_alsactl_write('example_spk_eq_iir.txt', bp_iir);
         eq_blob_write('example_spk_eq_iir.blob', bp_iir);
+	eq_tplg_write('example_spk_eq_iir.m4', bp_iir, 'IIR');
 end
 
 end
-


### PR DESCRIPTION
This patch adds export function for the m4 syntax bytes data and adds
the export of such blob to example designs. The example EQ designs are
edited to make this format export too.

In addition the example FIR length is adjusted to be near current IPC
length maximum (384) and improve the effect quality.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>