### PR TITLE
EQ FIR: Add check and removal for trailing zeros in filter coefficients

### DIFF
--- a/tune/eq/eq_fir_blob_quant.m
+++ b/tune/eq/eq_fir_blob_quant.m
@@ -44,15 +44,31 @@ if nargin < 2
 	bits = 16;
 end
 
+%% Quantize
 [bq, shift] = eq_fir_quantize(b, bits);
 
-nb = length(bq);
+%% Check trailing zeros
+nf = length(bq);
+nz = nf;
+while bq(nz) == 0
+	nz = nz - 1;
+end
+if nz < nf
+	nb = nz + 1;
+	fprintf(1,'Note: Filter length was reduced to %d -> %d due to trailing zeros.\n', ...
+		nf, nb);
+	bq = bq(1:nb);
+else
+	nb = nf;
+end
+
+%% Make length multiple of four (optimized FIR core)
 mod4 = mod(nb, 4);
 if mod4 > 0
 	pad = zeros(1,4-mod4);
 	bqp = [bq pad];
 	nnew = length(bqp);
-	fprintf(1,'Note: Filter length was %d, padded length into %d,\n', nb, nnew);
+	fprintf(1,'Note: Filter length was %d, padded length into %d.\n', nb, nnew);
 else
 	nnew = nb;
 	bqp = bq;


### PR DESCRIPTION
This patch adds removing of extra zeros in the FIR coefficients. The
zeros can happen in some responses due to fixed point quantization of
very small values. The zero taps consume DSP resources for nothing so
better to clean them out for EQ configuration data.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>