### PR TITLE
topology: sof-glk-da7219: update to use s32le format for HDMI pipelines

### DIFF
--- a/topology/sof-glk-da7219.m4
+++ b/topology/sof-glk-da7219.m4
@@ -55,25 +55,25 @@ PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
 	4, 99, 4, s32le,
 	48, 1000, 0, 0)
 
-# Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s16le.
+# Low Latency playback pipeline 5 on PCM 5 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        5, 5, 2, s16le,
+        5, 5, 2, s32le,
         48, 1000, 0, 0)
 
-# Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s16le.
+# Low Latency playback pipeline 6 on PCM 6 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        6, 6, 2, s16le,
+        6, 6, 2, s32le,
         48, 1000, 0, 0)
 
-# Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s16le.
+# Low Latency playback pipeline 7 on PCM 7 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 # PIPELINE_PCM_ADD(sof/pipe-passthrough-playback.m4,
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-        7, 7, 2, s16le,
+        7, 7, 2, s32le,
         48, 1000, 0, 0)
 
 #
@@ -102,31 +102,31 @@ DAI_ADD(sof/pipe-dai-capture.m4,
 	48, 1000, 0, 0)
 
 # capture DAI is DMIC0 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	4, DMIC, 0, dmic01,
 	PIPELINE_SINK_4, 2, s32le,
 	48, 1000, 0, 0)
 
 # playback DAI is iDisp1 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         5, HDA, 3, iDisp1,
-        PIPELINE_SOURCE_5, 2, s16le,
+        PIPELINE_SOURCE_5, 2, s32le,
         48, 1000, 0, 0)
 
 # playback DAI is iDisp2 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         6, HDA, 4, iDisp2,
-        PIPELINE_SOURCE_6, 2, s16le,
+        PIPELINE_SOURCE_6, 2, s32le,
         48, 1000, 0, 0)
 
 # playback DAI is iDisp3 using 2 periods
-# Buffers use s16le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
         7, HDA, 5, iDisp3,
-        PIPELINE_SOURCE_7, 2, s16le,
+        PIPELINE_SOURCE_7, 2, s32le,
         48, 1000, 0, 0)
 
 PCM_PLAYBACK_ADD(Speakers, 0, PIPELINE_PCM_1)


### PR DESCRIPTION
Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>