### PR TITLE
topology: enable hdmi support on UP2 board

### DIFF
--- a/topology/sof-apl-pcm512x.m4
+++ b/topology/sof-apl-pcm512x.m4
@@ -7,6 +7,7 @@ include(`utils.m4')
 include(`dai.m4')
 include(`pipeline.m4')
 include(`ssp.m4')
+include(`hda.m4')
 
 # Include TLV library
 include(`common/tlv.m4')
@@ -25,15 +26,42 @@ DEBUG_START
 # PCM0 ----> volume -----> SSP5 (pcm512x)
 #
 
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
 # Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
 	1, 0, 2, s32le,
 	48, 1000, 0, 0)
 
+# Low Latency playback pipeline 2 on PCM 1 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	2, 1, 2, s32le,
+	48, 1000, 0, 0)
+
+# Low Latency playback pipeline 3 on PCM 2 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	3, 2, 2, s32le,
+	48, 1000, 0, 0)
+
+# Low Latency playback pipeline 4 on PCM 3 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	4, 3, 2, s32le,
+	48, 1000, 0, 0)
+
 #
 # DAIs configuration
 #
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
 
 # playback DAI is SSP5 using 2 periods
 # Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
@@ -42,18 +70,50 @@ DAI_ADD(sof/pipe-dai-playback.m4,
 	PIPELINE_SOURCE_1, 2, s24le,
 	48, 1000, 0, 0)
 
+# playback DAI is iDisp1 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	2, HDA, 0, iDisp1,
+	PIPELINE_SOURCE_2, 2, s32le,
+	48, 1000, 0, 0)
+
+# playback DAI is iDisp2 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	3, HDA, 1, iDisp2,
+	PIPELINE_SOURCE_3, 2, s32le,
+	48, 1000, 0, 0)
+
+# playback DAI is iDisp3 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	4, HDA, 2, iDisp3,
+	PIPELINE_SOURCE_4, s32le,
+	48, 1000, 0, 0)
+
 # PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
 PCM_PLAYBACK_ADD(Port5, 0, PIPELINE_PCM_1)
+PCM_PLAYBACK_ADD(HDMI1, 1, PIPELINE_PCM_2)
+PCM_PLAYBACK_ADD(HDMI2, 2, PIPELINE_PCM_3)
+PCM_PLAYBACK_ADD(HDMI3, 3, PIPELINE_PCM_4)
 
 #
 # BE configurations - overrides config in ACPI if present
 #
 
+#SSP 5 (ID: 0)
 DAI_CONFIG(SSP, 5, 0, SSP5-Codec,
 	SSP_CONFIG(I2S, SSP_CLOCK(mclk, 24576000, codec_mclk_in),
 		SSP_CLOCK(bclk, 3072000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 32, 3, 3),
 		SSP_CONFIG_DATA(SSP, 5, 24)))
+
+# 3 HDMI/DP outputs (ID: 1,2,3)
+dnl HDA_DAI_CONFIG(dai_index, link_id, name)
+HDA_DAI_CONFIG(0, 1, iDisp1)
+HDA_DAI_CONFIG(1, 2, iDisp2)
+HDA_DAI_CONFIG(2, 3, iDisp3)
 
 DEBUG_END


### PR DESCRIPTION
Add HDMI support to sof-apl-pcm512x

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>