### PR TITLE
rmbox: change binary names of logger and rmbox

### DIFF
--- a/rmbox/Makefile.am
+++ b/rmbox/Makefile.am
@@ -1,12 +1,12 @@
-bin_PROGRAMS = rmbox logger
+bin_PROGRAMS = sof-rmbox sof-logger
 
-rmbox_SOURCES = \
+sof_rmbox_SOURCES = \
 	rmbox.c \
 	rmbox_convert.c
 
-logger_SOURCES = \
+sof_logger_SOURCES = \
 	rmbox.c \
 	logger_convert.c
 
-logger_CFLAGS = \
+sof_logger_CFLAGS = \
 	-DLOGGER_FORMAT

--- a/rmbox/rmbox.c
+++ b/rmbox/rmbox.c
@@ -22,9 +22,9 @@
 #include "convert.h"
 
 #ifdef LOGGER_FORMAT
-#define APP_NAME "logger"
+#define APP_NAME "sof-logger"
 #else
-#define APP_NAME "rmbox"
+#define APP_NAME "sof-rmbox"
 #endif
 
 #define ARRAY_SIZE(x) (sizeof(x)/sizeof(x[0]))


### PR DESCRIPTION
Change binary names:
- from logger to sof-logger
- from rmbox to sof-rmbox

Signed-off-by: Bartosz Kokoszko <bartoszx.kokoszko@linux.intel.com>