### PR TITLE
topology: duplicate dai formart for pcm add

### DIFF
--- a/topology/m4/pipeline.m4
+++ b/topology/m4/pipeline.m4
@@ -51,6 +51,7 @@ define(`PIPELINE_PCM_ADD',
 `define(`SCHEDULE_DEADLINE', $7)'
 `define(`SCHEDULE_PRIORITY', $8)'
 `define(`SCHEDULE_CORE', $9)'
+`define(`DAI_FORMAT', $5)'
 `include($1)'
 `DEBUG_PCM_ADD($1, $3)'
 )


### PR DESCRIPTION
In PIPELINE_PCM_ADD, DAI_FORMAT is not set but are used later.
Need to set this value to avoid protenial issues.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>