### PR TITLE
Test: Audio: Fix paths in SRC host version testbench

### DIFF
--- a/test/audio/src_run.sh
+++ b/test/audio/src_run.sh
@@ -10,7 +10,7 @@ FN_IN=$5
 FN_OUT=$6
 
 # The HOST_ROOT path need to be retrived from SOFT .configure command
-HOST_ROOT=../../host-root
+HOST_ROOT=../../../host-root
 HOST_EXE=$HOST_ROOT/bin/testbench
 HOST_LIB=$HOST_ROOT/lib
 
@@ -18,7 +18,7 @@ HOST_LIB=$HOST_ROOT/lib
 INFMT=s${BITS_IN}le
 OUTFMT=s${BITS_IN}le
 MCLK=24576k
-TPLG=../topology/test/test-playback-ssp2-mclk-0-I2S-${COMP}-${INFMT}-${OUTFMT}-48k-${MCLK}-nocodec.tplg
+TPLG=../../topology/test/test-playback-ssp2-mclk-0-I2S-${COMP}-${INFMT}-${OUTFMT}-48k-${MCLK}-nocodec.tplg
 
 # If binary test vectors
 if [ ${FN_IN: -4} == ".raw" ]; then

--- a/test/audio/src_test.m
+++ b/test/audio/src_test.m
@@ -46,7 +46,7 @@ function [n_fail, n_pass, n_na] = src_test(bits_in, bits_out, fs_in_list, fs_out
 
 addpath('std_utils');
 addpath('test_utils');
-addpath('../tune/src');
+addpath('../../tune/src');
 mkdir_check('plots');
 mkdir_check('reports');
 


### PR DESCRIPTION
The directories were restructured lately and this patch fixes the
changed paths issue.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>