### PR TITLE
EQ Tool: Add calibration data import

### DIFF
--- a/tune/eq/mls_rec_config.txt
+++ b/tune/eq/mls_rec_config.txt
@@ -1,5 +1,16 @@
-rec.ssh = 0;         % Set to 1 for remote capture
-rec.user = '';       % Set to user@domain for ssh
-rec.dir = '/tmp';    % Directory for temporary files
-rec.dev = 'hw:0,0';  % Audio capture device
-rec.nch = 2;         % Number audio capture channels to use
+%% Recording device configuration
+
+rec.ssh = 0;             % Set to 1 for remote capture
+rec.user = '';           % Set to user@domain for ssh
+rec.dir = '/tmp';        % Directory for temporary files
+rec.dev = 'hw:0,0';      % Audio capture device
+rec.nch = 2;             % Number audio capture channels to use
+
+% Use '' if calibration is not needed. Otherwise set to
+% e.g. '1234567.txt'. Such calibration data format is supported for
+% some reasonably priced measurement microphones. The ASCII text
+% calibration data file is the measured frequency response of the used
+% microphone. Lines in the beginning those start with character " are
+% treated as comment. The successive lines should be <frequency>
+% <magnitude> number pairs. Their unit must be Hz and dB.
+rec.cal = '';


### PR DESCRIPTION
This patch adds capability to apply for capture microphone calibration
data (ASCII text lines with Hz, dB values). The calibration data file
name needs to be edited into configuration file mls_rec_config.txt. Such
calibration data is provided by several inexpensive USB measurement
microphones manufacturers.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>