### PR TITLE
topology: add 4-ch dmic topology for ICL

### DIFF
--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -42,7 +42,8 @@ MACHINES = \
 	sof-apl-eq-pcm512x.tplg \
 	sof-apl-eq-dmic.tplg \
 	sof-apl-dmic-2ch.tplg \
-	sof-apl-dmic-4ch.tplg
+	sof-apl-dmic-4ch.tplg \
+	sof-icl-dmic-4ch.tplg
 
 
 # Uncomment the following line if you want to debug conf files

--- a/topology/sof-icl-dmic-4ch.m4
+++ b/topology/sof-icl-dmic-4ch.m4
@@ -1,0 +1,68 @@
+#
+# Topology for ICL Lake with direct attach digital microphones array
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include Apollolake DSP configuration
+include(`platform/intel/bxt.m4')
+include(`platform/intel/dmic.m4')
+
+#
+# Define the pipelines
+#
+# PCM6 <---- volume <----- DMIC01 (dmic0 capture)
+#
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+
+# Passthrough capture pipeline 1 on PCM 1 using max 4 channels.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	1, 1, 4, s32le,
+	48, 1000, 0, 0)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+
+# capture DAI is DMIC 0 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	1, DMIC, 0, dmic01,
+	PIPELINE_SINK_1, 2, s32le,
+	48, 1000, 0, 0)
+
+dnl PCM_DUPLEX_ADD(name, pcm_id, playback, capture)
+
+dnl PCM_CAPTURE_ADD(name, pipeline, capture)
+PCM_CAPTURE_ADD(DMIC01, 1, PIPELINE_PCM_1)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+dnl DAI_CONFIG(type, dai_index, link_id, name, ssp_config/dmic_config)
+
+DAI_CONFIG(DMIC, 0, 1, dmic01,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))


### PR DESCRIPTION
Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>